### PR TITLE
Russian translation

### DIFF
--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+  <string name="app_name">Feeder</string>
+  <string name="navigation_drawer_open"/>
+  <string name="navigation_drawer_close"/>
+  <string name="action_settings">Настройки</string>
+  <string name="add_feed">Добавить ленту</string>
+  <string name="title_activity_edit_feed">Подписаться на ленту</string>
+  <string name="url">URL</string>
+  <string name="tag">Тег</string>
+  <string name="add_feed_search_hint">URL ленты</string>
+  <string name="title">Название</string>
+
+  <string name="save">Сохранить</string>
+  <string name="empty_feed_top">Здесь нечего читать. Хотите…</string>
+  <string name="empty_feed_open">
+ &lt;font color=#607D8B&gt;Открыть&lt;/font&gt; другую ленту?</string>
+  <string name="empty_feed_add">
+ &lt;font color=#607D8B&gt;Добавить&lt;/font&gt; ещё ленту?</string>
+  <string name="empty_no_feeds_top">"Пока нечего читать.
+Начните
+ с
+ "</string>
+  <string name="empty_no_feeds_add">
+ &lt;font color=#607D8B&gt;Добавления&lt;/font&gt; каких-нибудь лент</string>
+  <string name="search_feed_empty_hint">Введите адрес ленты</string>
+  <string name="edit_feed">Изменить ленту</string>
+  <string name="delete_feed">Удалить ленту</string>
+  <string name="show_all_items">Показать все записи</string>
+  <string name="show_unread_items">Показать непрочитанные записи</string>
+  <string name="new_items_available">Доступны новые записи</string>
+  <string name="view">Вид</string>
+  <string name="username">Имя пользователя</string>
+  <string name="server_address">Адрес сервера</string>
+  <string name="night_mode">Ночной режим</string>
+  <string name="open_link_in_browser">Открыть ссылку в браузере</string>
+  <string name="open_enclosed_media">Открыть прикреплённый медиафайл</string>
+  <string name="sync">Синхронизировать</string>
+  <string name="export_feeds_to_opml">Экспорт лент в OPML</string>
+  <string name="import_feeds_from_opml">Импорт лент из OPML</string>
+  <string name="view_debug_log">Открыть журнал отладки</string>
+  <string name="share">Поделиться</string>
+  <string name="no_such_feed">Не удалось найти такую ленту. Попробуйте с https.</string>
+  <string name="title_activity_settings">Настройки</string>
+
+  <string name="synchronization">Синхронизация</string>
+  <string name="only_on_wifi">Только по Wi-Fi</string>
+  <string name="may_result_data_charges">Может привести к расходам на мобильные данные.</string>
+  <string name="only_when_charging">Только при зарядке</string>
+  <string name="image_loading">Загрузка изображений</string>
+  <string name="no_activity_for_link">Не удалось найти приложение, чтобы открыть ссылку</string>
+
+</resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -44,6 +44,14 @@
   <string name="no_such_feed">Не удалось найти такую ленту. Попробуйте с https.</string>
   <string name="title_activity_settings">Настройки</string>
 
+  <string-array name="pref_sync_frequency_titles">
+    <item>Вручную</item>
+    <item>Каждый час</item>
+    <item>Каждые 3 часа</item>
+    <item>Каждые 6 часов</item>
+    <item>Каждые 12 часов</item>
+  </string-array>
+
   <string name="synchronization">Синхронизация</string>
   <string name="only_on_wifi">Только по Wi-Fi</string>
   <string name="may_result_data_charges">Может привести к расходам на мобильные данные.</string>


### PR DESCRIPTION
It's somewhat incomplete right now, but the most obvious UI elements are translated.

There are still some hardcoded strings in settings.xml, for example:
```xml
res/xml/settings.xml:9:        android:title="Check for updates" android:entries="@array/pref_sync_frequency_titles"
res/xml/settings.xml:16:        android:title="Include mobile hotspots" android:key="pref_sync_hotspots"
res/xml/settings.xml:30:        android:title="Include mobile hotspots" android:key="pref_img_hotspots"
```

Also there are some seemingly unused strings still present (and marked as translatable), for example:
```xml
  <string name="title_section1">Section 1</string>
  <string name="title_section2">Section 2</string>
  <string name="title_section3">Section 3</string>
 ...
  <string name="dummy_button">Dummy Button</string>
  <string name="dummy_content">DUMMY\nCONTENT</string>
```
And there are strings like `<string name="hello_world">Hello world!</string>`, which are used, but are also kinda weird to see as translatable.

I'll keep an eye (or rather, a :star:) on this project, so you can merge this PR and then fix whatever you think needs fixing, and I'll catch up with the changes and update values-ru/strings.xml later.