### PR TITLE
Update manifest according API 30 package visibility filtering

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -136,4 +136,10 @@
       android:exported="true" />
   </application>
 
+  <queries>
+    <intent>
+      <action android:name="android.intent.action.PROCESS_TEXT" />
+      <data android:mimeType="text/plain" />
+    </intent>
+  </queries>
 </manifest>


### PR DESCRIPTION
According [Androind documentation](https://developer.android.com/training/package-visibility) if an app targets API level 30+ then the system filters queries for information about the other apps that are installed on a device.
This results in the context menu of the selected text not showing text processors such as Google Translate.
The PR is intended to fix the issue and improve the usability of Feeder.

Apparently, this does not make sense for the master branch due to current Jetpack Compose limitations.
But the hotfix is preferable to be backported to the current market version.

Thanks for your efforts and attention
