### PR TITLE
Set jvm target to 11

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,6 +44,10 @@ android {
                 argument("room.incremental", "true")
             }
         }
+
+        kotlinOptions {
+            jvmTarget = "11"
+        }
     }
 
     sourceSets {


### PR DESCRIPTION
Fixes the following:

> Task :jsonfeed-parser:compileKotlin
'compileJava' task (current target is 11) and 'compileKotlin' task
  (current target is 1.8) jvm target compatibility should be set to
  the same Java version.
By default will become an error since Gradle 8.0+! Read more:
  https://kotl.in/gradle/jvm/target-validation
Consider using JVM toolchain: https://kotl.in/gradle/jvm/toolchain