### PR TITLE
Add ability to search current feed by title of feed item

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/archmodel/Repository.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/archmodel/Repository.kt
@@ -228,6 +228,12 @@ class Repository(override val di: DI) : DIAware {
         sessionStore.setResumeTime(value)
     }
 
+    val searchText = sessionStore.searchText
+
+    fun setSearchText(searchText: String?) {
+        sessionStore.setSearchText(searchText?.ifEmpty { null })
+    }
+
     /**
      * Returns EPOCH is no sync is currently happening
      */
@@ -244,7 +250,8 @@ class Repository(override val di: DI) : DIAware {
         minReadTime,
         currentSorting,
         feedListFilter,
-    ) { feedAndTag, minReadTime, currentSorting, feedListFilter ->
+        searchText,
+    ) { feedAndTag, minReadTime, currentSorting, feedListFilter, searchText ->
         val (feedId, tag) = feedAndTag
         FeedListArgs(
             feedId = feedId,
@@ -255,6 +262,7 @@ class Repository(override val di: DI) : DIAware {
             },
             newestFirst = currentSorting == SortingOptions.NEWEST_FIRST,
             filter = feedListFilter,
+            searchText = searchText,
         )
     }.flatMapLatest {
         feedItemStore.getPagedFeedItemsRaw(
@@ -263,6 +271,7 @@ class Repository(override val di: DI) : DIAware {
             minReadTime = it.minReadTime,
             newestFirst = it.newestFirst,
             filter = it.filter,
+            searchText = it.searchText,
         )
     }
 
@@ -658,6 +667,7 @@ private data class FeedListArgs(
     val newestFirst: Boolean,
     val minReadTime: Instant,
     val filter: FeedListFilter,
+    val searchText: String? = null,
 )
 
 // Wrapper class because flow combine doesn't like nulls

--- a/app/src/main/java/com/nononsenseapps/feeder/archmodel/SessionStore.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/archmodel/SessionStore.kt
@@ -31,4 +31,11 @@ class SessionStore {
             }
         }
     }
+
+    private val _searchText: MutableStateFlow<String?> = MutableStateFlow(null)
+    val searchText: StateFlow<String?> = _searchText.asStateFlow()
+
+    fun setSearchText(searchText: String?) {
+        _searchText.update { searchText }
+    }
 }

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
@@ -472,14 +472,17 @@ fun FeedScreen(
         onEditFeed = onEditFeed,
         toolbarActions = {
             if (viewState.currentFeedOrTag.isNotSavedArticles) {
-                Box {
-                    IconButton(
-                        onClick = { onShowSearchField(true) }
-                    ) {
-                        Icon(
-                            Icons.Default.Search,
-                            contentDescription = stringResource(R.string.search_noun),
-                        )
+                PlainTooltipBox(tooltip = { Text(stringResource(id = R.string.search_noun)) }) {
+                    Box {
+                        IconButton(
+                            onClick = { onShowSearchField(true) },
+                            modifier = Modifier.tooltipAnchor(),
+                        ) {
+                            Icon(
+                                Icons.Default.Search,
+                                contentDescription = stringResource(R.string.search_noun),
+                            )
+                        }
                     }
                 }
                 PlainTooltipBox(tooltip = { Text(stringResource(id = R.string.filter_noun)) }) {

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/FeedArticleViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/FeedArticleViewModel.kt
@@ -171,6 +171,25 @@ class FeedArticleViewModel(
 
     val filterCallback: FeedListFilterCallback = this
 
+    private val searchFieldVisible: MutableStateFlow<Boolean> =
+        MutableStateFlow(state["showSearchField"] ?: false)
+
+    fun setSearchFieldVisible(visible: Boolean) {
+        state["showSearchField"] = visible
+        searchFieldVisible.update { visible }
+    }
+
+    fun hideSearchField() {
+        setSearchText("")
+        setSearchFieldVisible(false)
+    }
+
+    private val searchText: StateFlow<String?> = repository.searchText
+
+    fun setSearchText(searchTextVal: String) {
+        repository.setSearchText(searchTextVal)
+    }
+
     fun toggleTagExpansion(tag: String) = repository.toggleTagExpansion(tag)
 
     private val editDialogVisible = MutableStateFlow(false)
@@ -277,7 +296,9 @@ class FeedArticleViewModel(
             filterMenuVisible,
             repository.feedListFilter,
             repository.showOnlyTitle,
-        ) { params: Array<Any> ->
+            searchFieldVisible,
+            searchText,
+        ) { params: Array<Any?> ->
             val article = params[16] as Article
 
             val ttsState = params[17] as PlaybackStatus
@@ -326,6 +347,8 @@ class FeedArticleViewModel(
                 showFilterMenu = params[25] as Boolean,
                 filter = params[26] as FeedListFilter,
                 showOnlyTitle = params[27] as Boolean,
+                showSearchField = params[28] as Boolean,
+                searchText = params[29] as String?,
             )
         }
             .stateIn(
@@ -479,6 +502,8 @@ interface FeedScreenViewState {
     val showOnlyTitle: Boolean
     val filter: FeedListFilter
     val showFilterMenu: Boolean
+    val showSearchField: Boolean
+    val searchText: String?
 }
 
 interface ArticleScreenViewState {
@@ -581,5 +606,7 @@ data class FeedArticleScreenViewState(
     override val showOnlyTitle: Boolean = false,
     override val showFilterMenu: Boolean = false,
     override val filter: FeedListFilter = emptyFeedListFilter,
+    override val showSearchField: Boolean = false,
+    override val searchText: String? = null,
     val isArticleOpen: Boolean = false,
 ) : FeedScreenViewState, ArticleScreenViewState

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/theme/SearchTopAppBar.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/theme/SearchTopAppBar.kt
@@ -1,0 +1,126 @@
+package com.nononsenseapps.feeder.ui.compose.theme
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults.topAppBarColors
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.material3.surfaceColorAtElevation
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import com.nononsenseapps.feeder.R
+import com.nononsenseapps.feeder.ui.compose.utils.ThemePreviews
+
+/**
+ * On a small but tall screen this will be a LargeTopAppBar to make the screen
+ * more one-hand friendly.
+ *
+ * One a short screen - or bigger tablet size - then it's a small top app bar which can scoll
+ * out of the way to make best use of the available screen space.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SearchTopAppBar(
+    searchText: String? = null,
+    onSearchChange: (String) -> Unit,
+    hideSearchField: () -> Unit,
+    scrollBehavior: TopAppBarScrollBehavior? = null,
+) {
+    TopAppBar(
+        scrollBehavior = scrollBehavior,
+        title = {
+            val focusRequester = remember { FocusRequester() }
+            val interactionSource = remember {
+                MutableInteractionSource()
+            }
+            val inputText = remember {
+                mutableStateOf(searchText ?: "")
+            }
+
+
+            BasicTextField(
+                value = inputText.value,
+                onValueChange = {
+                    inputText.value = it
+                    onSearchChange(it)
+                },
+                textStyle = TextStyle.Default.copy(
+                    color = LocalContentColor.current,
+                ),
+                interactionSource = interactionSource,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(end = 16.dp)
+                    .focusRequester(focusRequester),
+                decorationBox = @Composable { innerTextField ->
+                    OutlinedTextFieldDefaults.DecorationBox(
+                        value = searchText ?: "",
+                        innerTextField = innerTextField,
+                        enabled = true,
+                        singleLine = true,
+                        visualTransformation = VisualTransformation.None,
+                        interactionSource = interactionSource,
+                        leadingIcon = {
+                            Icon(Icons.Default.Search, "")
+                        },
+                        trailingIcon = {
+                            IconButton(
+                                onClick = hideSearchField
+                            ) {
+                                Icon(Icons.Default.Clear, "")
+                            }
+                        },
+                        contentPadding = PaddingValues(2.dp),
+                        placeholder = {
+                            Text(text = stringResource(R.string.search_noun))
+                        },
+                    )
+                },
+            )
+            LaunchedEffect(Unit, searchText) {
+                if(searchText === null){
+                    focusRequester.requestFocus()
+                }
+            }
+        },
+        colors = topAppBarColors(
+            containerColor = MaterialTheme.colorScheme.background,
+            scrolledContainerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(3.dp),
+        ),
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+@ThemePreviews
+fun SearchTopAppBarPreview(){
+    FeederTheme {
+        SearchTopAppBar(
+            searchText = "Sample text",
+            onSearchChange = {},
+            hideSearchField = {},
+        )
+    }
+}

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/theme/SearchTopAppBar.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/theme/SearchTopAppBar.kt
@@ -83,13 +83,13 @@ fun SearchTopAppBar(
                         visualTransformation = VisualTransformation.None,
                         interactionSource = interactionSource,
                         leadingIcon = {
-                            Icon(Icons.Default.Search, "")
+                            Icon(Icons.Default.Search, stringResource(id = R.string.search_noun))
                         },
                         trailingIcon = {
                             IconButton(
                                 onClick = hideSearchField
                             ) {
-                                Icon(Icons.Default.Clear, "")
+                                Icon(Icons.Default.Clear, stringResource(id = R.string.clear_search_noun))
                             }
                         },
                         contentPadding = PaddingValues(2.dp),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -225,6 +225,7 @@
   <string name="failed_to_fetch_full_article_not_html">Link is not an HTML document</string>
   <string name="max_lines">Max lines</string>
   <string name="filter_noun">Filter</string>
+  <string name="search_noun">Search</string>
   <string name="recently_read_adjective">Recently read</string>
   <string name="read_adjective">Read</string>
   <string name="saved_adjective">Saved</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -226,6 +226,7 @@
   <string name="max_lines">Max lines</string>
   <string name="filter_noun">Filter</string>
   <string name="search_noun">Search</string>
+  <string name="clear_search_noun">Clear search</string>
   <string name="recently_read_adjective">Recently read</string>
   <string name="read_adjective">Read</string>
   <string name="saved_adjective">Saved</string>


### PR DESCRIPTION
Hey! Love the app. Use it all the time. I've ran into this a few times, where I've seen an article then it's been a few hours and trying to find it again proves really difficult with a few hundred items in the list. I've added a search icon on the navigation bar which converts to a search field and filters the current page query by the text entered. It's my first time using Compose and Kotlin so bear with me, but I think I followed the repo's expectations fairly well.

Only concern I have with the 'functionality' is filtering a list then using one of the "Mark above as read...", etc, marks any newer / older items as read instead of the filtered ones. It wouldn't be terribly difficult to go back and have those updated with that same behavior, but figured I would ask here before I did that as well (and if the whole PR would be accepted in general).

Example here:

https://github.com/spacecowboy/Feeder/assets/3063830/ef3ec6e0-2ebe-4a4c-9de5-23b147ea6e61
