### PR TITLE
Fix notifications not following settings for item opening

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/model/RssNotifications.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/RssNotifications.kt
@@ -125,7 +125,7 @@ private fun createNotificationChannel(context: Context) {
     notificationManager.createNotificationChannel(channel)
 }
 
-private fun singleNotification(context: Context, item: FeedItemWithFeed): Notification {
+private suspend fun singleNotification(context: Context, item: FeedItemWithFeed): Notification {
     val style = NotificationCompat.BigTextStyle()
     val title = item.plainTitle
     val text = item.feedDisplayTitle
@@ -162,7 +162,8 @@ private fun singleNotification(context: Context, item: FeedItemWithFeed): Notifi
 
     val di by closestDI(context)
     val repository: Repository by di.instance()
-    if (repository.itemOpener.value == ItemOpener.DEFAULT_BROWSER && item.link != null) {
+
+    if (repository.getArticleOpener(item.id) == ItemOpener.DEFAULT_BROWSER && item.link != null) {
         builder.setContentIntent(
             PendingIntent.getActivity(
                 context,
@@ -190,7 +191,7 @@ private fun singleNotification(context: Context, item: FeedItemWithFeed): Notifi
         )
     }
 
-    if (repository.itemOpener.value != ItemOpener.DEFAULT_BROWSER) {
+    if (repository.getArticleOpener(item.id) != ItemOpener.DEFAULT_BROWSER) {
         item.link?.let { link ->
             builder.addAction(
                 R.drawable.notification_open_in_browser,

--- a/app/src/main/java/com/nononsenseapps/feeder/model/RssNotifications.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/RssNotifications.kt
@@ -126,6 +126,9 @@ private fun createNotificationChannel(context: Context) {
 }
 
 private suspend fun singleNotification(context: Context, item: FeedItemWithFeed): Notification {
+    val di by closestDI(context)
+    val repository: Repository by di.instance()
+
     val style = NotificationCompat.BigTextStyle()
     val title = item.plainTitle
     val text = item.feedDisplayTitle
@@ -159,9 +162,6 @@ private suspend fun singleNotification(context: Context, item: FeedItemWithFeed)
         .setNumber(1)
 
     // Note that notifications must use PNG resources, because there is no compatibility for vector drawables here
-
-    val di by closestDI(context)
-    val repository: Repository by di.instance()
 
     if (repository.getArticleOpener(item.id) == ItemOpener.DEFAULT_BROWSER && item.link != null) {
         builder.setContentIntent(


### PR DESCRIPTION
### Motivation
The problem this attempts to fix is that when clicking on a single item notification, the app is opened, ignoring the settings for opening items.
While a dedicated action for opening in the browser is present, it does not solve the issue, as an additional click is required to expand the buttons. 

### Implemented changes
This PR opens the item in the browser directly and hides the "open in browser" button when the item's default is set this way.
![image](https://github.com/spacecowboy/Feeder/assets/82763757/32bb1156-942b-4fe5-99bd-62ae8c0444ed)


### Potential issues with this PR
Notification builders only check for opening in the browser there might be a more general way to implement this. If this is a concern please point out the functions needed so I can modify the code accordingly.

The "open in browser" button could be replaced with an "open in app" button when the browser setting is set. I did not implement this to keep the changes simple.
