### PR TITLE
Implemented 'Exclude from "All feeds"' setting

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/archmodel/FeedItemStore.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/archmodel/FeedItemStore.kt
@@ -134,6 +134,7 @@ class FeedItemStore(override val di: DI) : DIAware {
             onlySavedArticles -> append("AND bookmarked = 1\n")
             feedId > ID_UNSET -> append("AND feed_id IS ?\n").also { args.add(feedId) }
             tag.isNotEmpty() -> append("AND tag IS ?\n").also { args.add(tag) }
+            feedId <= ID_UNSET -> append("AND (SELECT exclude_from_all_feeds FROM feeds WHERE feeds.id = feed_items.feed_id) IS 0\n")
         }
     }
 

--- a/app/src/main/java/com/nononsenseapps/feeder/db/Constants.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/db/Constants.kt
@@ -50,6 +50,7 @@ const val COL_READ_TIME = "read_time"
 const val COL_SITE_FETCHED = "site_fetched"
 const val COL_WORD_COUNT = "word_count"
 const val COL_WORD_COUNT_FULL = "word_count_full"
+const val COL_EXCLUDE_FROM_ALL_FEEDS = "exclude_from_all_feeds"
 
 // year 5000
 val FAR_FUTURE = Instant.ofEpochSecond(95635369646)

--- a/app/src/main/java/com/nononsenseapps/feeder/db/room/AppDatabase.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/db/room/AppDatabase.kt
@@ -127,12 +127,23 @@ fun getAllMigrations(di: DI) =
         MigrationFrom29To30(di),
         MigrationFrom30To31(di),
         MigrationFrom31To32(di),
+        MigrationFrom32To33(di),
     )
 
 /*
  * 6 represents legacy database
  * 7 represents new Room database
  */
+class MigrationFrom32To33(override val di: DI) : Migration(32, 33), DIAware {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL(
+            """
+            alter table feeds add column exclude_from_all_feeds integer not null default 0
+            """.trimIndent(),
+        )
+    }
+}
+
 class MigrationFrom31To32(override val di: DI) : Migration(31, 32), DIAware {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.execSQL(

--- a/app/src/main/java/com/nononsenseapps/feeder/db/room/Feed.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/db/room/Feed.kt
@@ -8,6 +8,7 @@ import androidx.room.PrimaryKey
 import com.nononsenseapps.feeder.db.COL_ALTERNATE_ID
 import com.nononsenseapps.feeder.db.COL_CURRENTLY_SYNCING
 import com.nononsenseapps.feeder.db.COL_CUSTOM_TITLE
+import com.nononsenseapps.feeder.db.COL_EXCLUDE_FROM_ALL_FEEDS
 import com.nononsenseapps.feeder.db.COL_FULLTEXT_BY_DEFAULT
 import com.nononsenseapps.feeder.db.COL_ID
 import com.nononsenseapps.feeder.db.COL_IMAGEURL
@@ -54,6 +55,7 @@ data class Feed
         // Only update this field when user modifies the feed
         @ColumnInfo(name = COL_WHEN_MODIFIED) var whenModified: Instant = Instant.EPOCH,
         @ColumnInfo(name = COL_SITE_FETCHED) var siteFetched: Instant = Instant.EPOCH,
+        @ColumnInfo(name = COL_EXCLUDE_FROM_ALL_FEEDS) var excludeFromAllFeeds: Boolean = false,
     ) {
         constructor() : this(id = ID_UNSET)
 

--- a/app/src/main/java/com/nononsenseapps/feeder/model/opml/OpmlPullParser.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/opml/OpmlPullParser.kt
@@ -48,6 +48,8 @@ private const val ATTR_OPEN_ARTICLES_WITH = "openArticlesWith"
 
 private const val TAG_BLOCKED = "blocked"
 
+private const val ATTR_EXCLUDE_FROM_ALL_FEEDS = "excludeFromAllFeeds"
+
 @Suppress("NAME_SHADOWING")
 class OpmlPullParser(private val opmlToDb: OPMLParserHandler) {
     private val feeds: MutableList<Feed> = mutableListOf()
@@ -296,6 +298,10 @@ class OpmlPullParser(private val opmlToDb: OPMLParserHandler) {
                                         null
                                     }
                                 } ?: feed.imageUrl,
+                        excludeFromAllFeeds =
+                            parser.getAttributeValue(OPML_FEEDER_NAMESPACE, ATTR_EXCLUDE_FROM_ALL_FEEDS)
+                                ?.toBoolean()
+                                ?: feed.excludeFromAllFeeds,
                     )
                 }
 

--- a/app/src/main/java/com/nononsenseapps/feeder/model/opml/OpmlWriter.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/opml/OpmlWriter.kt
@@ -233,6 +233,7 @@ abstract class BodyTag(name: String) : TagWithText(name) {
             fullTextByDefault = feed.fullTextByDefault
             openArticlesWith = feed.openArticlesWith
             alternateId = feed.alternateId
+            excludeFromAllFeeds = feed.excludeFromAllFeeds
         }
 }
 
@@ -287,6 +288,11 @@ class Outline : BodyTag("outline") {
         get() = attributes["feeder:alternateId"]!!.toBoolean()
         set(value) {
             attributes["feeder:alternateId"] = value.toString()
+        }
+    var excludeFromAllFeeds: Boolean
+        get() = attributes["feeder:excludeFromAllFeeds"]!!.toBoolean()
+        set(value) {
+            attributes["feeder:excludeFromAllFeeds"] = value.toString()
         }
 }
 

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/editfeed/CreateFeedScreenViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/editfeed/CreateFeedScreenViewModel.kt
@@ -44,6 +44,7 @@ class CreateFeedScreenViewModel(
     override var allTags: List<String> by mutableStateOf(emptyList())
     override var defaultTitle: String by mutableStateOf(state["feedTitle"] ?: "")
     override var feedImage: String by mutableStateOf(state["feedImage"] ?: "")
+    override var excludeFromAllFeeds: Boolean by mutableSavedStateOf(state, false)
 
     override val isOpenItemWithBrowser: Boolean
         get() = articleOpener == PREF_VAL_OPEN_WITH_BROWSER
@@ -90,6 +91,7 @@ class CreateFeedScreenViewModel(
                         alternateId = alternateId,
                         whenModified = Instant.now(),
                         imageUrl = sloppyLinkToStrictURLOrNull(feedImage),
+                        excludeFromAllFeeds = excludeFromAllFeeds,
                     ),
                 )
 

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/editfeed/EditFeedScreen.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/editfeed/EditFeedScreen.kt
@@ -510,6 +510,11 @@ fun ColumnScope.RightContent(
         description = stringResource(id = R.string.only_enable_for_bad_id_feeds),
         icon = null,
     ) { viewState.alternateId = it }
+    SwitchSetting(
+        title = stringResource(id = R.string.exclude_from_all_feeds),
+        checked = viewState.excludeFromAllFeeds,
+        icon = null,
+    ) { viewState.excludeFromAllFeeds = it }
     Divider(
         modifier = Modifier.fillMaxWidth(),
     )
@@ -566,6 +571,7 @@ interface EditFeedScreenState {
     var notify: Boolean
     var articleOpener: String
     var alternateId: Boolean
+    var excludeFromAllFeeds: Boolean
     val isOkToSave: Boolean
     val isNotValidUrl: Boolean
     val isOpenItemWithBrowser: Boolean
@@ -597,6 +603,7 @@ private class ScreenState(
     override var notify: Boolean by mutableStateOf(false)
     override var articleOpener: String by mutableStateOf("")
     override var alternateId: Boolean by mutableStateOf(false)
+    override var excludeFromAllFeeds: Boolean by mutableStateOf(false)
 }
 
 @Preview("Edit Feed Phone")

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/editfeed/EditFeedScreenViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/editfeed/EditFeedScreenViewModel.kt
@@ -44,6 +44,7 @@ class EditFeedScreenViewModel(
     override var notify: Boolean by mutableSavedStateOf(state, false)
     override var articleOpener: String by mutableSavedStateOf(state, "")
     override var alternateId: Boolean by mutableSavedStateOf(state, false)
+    override var excludeFromAllFeeds: Boolean by mutableSavedStateOf(state, false)
     override var allTags: List<String> by mutableStateOf(emptyList())
 
     override var feedImage: String by mutableStateOf("")
@@ -103,6 +104,9 @@ class EditFeedScreenViewModel(
             if (!state.contains("alternateId")) {
                 alternateId = feed.alternateId
             }
+            if (!state.contains("excludeFromAllFeeds")) {
+                excludeFromAllFeeds = feed.excludeFromAllFeeds
+            }
 
             repository.allTags
                 .collect { value ->
@@ -127,6 +131,7 @@ class EditFeedScreenViewModel(
                     notify = notify,
                     openArticlesWith = articleOpener,
                     alternateId = alternateId,
+                    excludeFromAllFeeds = excludeFromAllFeeds,
                 )
 
             // No point in doing anything unless they actually differ

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,6 +53,7 @@
   <string name="nothing_to_display">Nothing to display!</string>
   <string name="title_activity_settings">Settings</string>
   <string name="all_feeds">All feeds</string>
+  <string name="exclude_from_all_feeds">Exclude from All feeds</string>
 
   <string name="sync_option_manually">Manually</string>
   <string name="sync_option_every_15min">Every 15 minutes</string>


### PR DESCRIPTION
Someone requested it in discussion #122 and I recently started having the same problem.

This commit adds a feed setting "Exclude from All feeds", if set the feed items of that feed won't appear in the All feeds tab.