### PR TITLE
fix: unread count in title for groups (tags)

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/archmodel/Repository.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/archmodel/Repository.kt
@@ -97,13 +97,15 @@ class Repository(override val di: DI) : DIAware {
 
     val currentFeedAndTag: StateFlow<Pair<Long, String>> = settingsStore.currentFeedAndTag
 
-    fun getUnreadCount(feedId: Long) =
-        feedItemStore.getFeedItemCountRaw(
-            feedId = feedId,
-            tag = "",
-            minReadTime = Instant.now(),
-            filter = emptyFeedListFilter,
-        )
+    fun getUnreadCount(
+        feedId: Long,
+        tag: String = "",
+    ) = feedItemStore.getFeedItemCountRaw(
+        feedId = feedId,
+        tag = tag,
+        minReadTime = Instant.now(),
+        filter = emptyFeedListFilter,
+    )
 
     fun setCurrentFeedAndTag(
         feedId: Long,
@@ -419,7 +421,7 @@ class Repository(override val di: DI) : DIAware {
     fun getScreenTitleForFeedOrTag(
         feedId: Long,
         tag: String,
-    ) = getUnreadCount(feedId).mapLatest { unreadCount ->
+    ) = getUnreadCount(feedId, tag).mapLatest { unreadCount ->
         ScreenTitle(
             title =
                 when {
@@ -441,7 +443,7 @@ class Repository(override val di: DI) : DIAware {
     @OptIn(ExperimentalCoroutinesApi::class)
     fun getScreenTitleForCurrentFeedOrTag(): Flow<ScreenTitle> =
         currentFeedAndTag.flatMapLatest { (feedId, tag) ->
-            getUnreadCount(feedId).mapLatest { unreadCount ->
+            getUnreadCount(feedId, tag).mapLatest { unreadCount ->
                 ScreenTitle(
                     title =
                         when {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -248,6 +248,6 @@
     <string name="skip_duplicate_articles">Doppelte Artikel überspringen</string>
     <string name="skip_duplicate_articles_desc">Artikel mit Links oder Titeln, die mit bestehenden Artikeln identisch sind, werden ignoriert</string>
     <string name="feed_item_style_compact_card">Kompakte Kartei</string>
-    <string name="show_title_unread_count">Zeige Anzahl ungelesener Artikel im Titel</string>
+    <string name="show_title_unread_count">Anzahl ungelesener Artikel im Titel anzeigen</string>
     <string name="touch_to_play_audio">Berühren, um Audio abzuspielen</string>
 </resources>


### PR DESCRIPTION
The `tag` parameter wasn't passed to `getUnreadCount()` so the unread count of groups (tags) was incorrect.

I also slightly adjusted the German translation to be more in line with the other phrasing.