### PR TITLE
Fix the scaling of small thumbnails

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedItemCard.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedItemCard.kt
@@ -125,7 +125,7 @@ fun FeedItemCard(
                                         )
                                         .scale(Scale.FIT)
                                         .size(pixels)
-                                        .precision(Precision.INEXACT)
+                                        .precision(Precision.EXACT)
                                         .build(),
                                 placeholder = rememberTintedVectorPainter(Icons.Outlined.Terrain),
                                 error = rememberTintedVectorPainter(Icons.Outlined.ErrorOutline),


### PR DESCRIPTION
Small images appear to not scale correctly when Precision.INEXACT is used rather than Precision.EXACT. As you can see from the images below, with the fix applied the thumbnails scale to fit the frame rather than having the huge border shown.
Please note that the feed is somewhat broken and their thumbnails are low quality and sometimes stretched.
![1](https://github.com/user-attachments/assets/f118bcaa-085c-4661-859d-d8dcc8ce04aa)
![2](https://github.com/user-attachments/assets/59b893d1-1897-48d9-bb36-963df3628fb9)
