### PR TITLE
fix: feed title empty on initial app start

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/archmodel/Repository.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/archmodel/Repository.kt
@@ -455,10 +455,10 @@ class Repository(override val di: DI) : DIAware {
                             else -> null
                         },
                     type =
-                        when (feedId) {
-                            ID_UNSET -> FeedType.TAG
-                            ID_ALL_FEEDS -> FeedType.ALL_FEEDS
-                            ID_SAVED_ARTICLES -> FeedType.SAVED_ARTICLES
+                        when {
+                            tag.isNotBlank() -> FeedType.TAG
+                            feedId == ID_UNSET || feedId == ID_ALL_FEEDS -> FeedType.ALL_FEEDS
+                            feedId == ID_SAVED_ARTICLES -> FeedType.SAVED_ARTICLES
                             else -> FeedType.FEED
                         },
                     unreadCount = unreadCount,


### PR DESCRIPTION
On the first app start the feed title is empty.

![Screenshot_20241013_124246](https://github.com/user-attachments/assets/1528e26c-2c17-4069-8392-9b19086efb5b)

`SettingsStore` returns `ID_UNSET` for the current feed because the user has not explicitly selected a feed yet.

The PR fixes it by setting `FeedType` to `ALL_FEEDS` when ID is `ID_UNSET` (and `tag` is blank).