### PR TITLE
[Hotfix] Show snippet of feed instead of "Found nothing to fetch"

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/archmodel/Repository.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/archmodel/Repository.kt
@@ -881,6 +881,7 @@ data class Article(
     val link: String? = item?.link
     val feedDisplayTitle: String = item?.feedDisplayTitle ?: ""
     val title: String = item?.plainTitle ?: ""
+    val snippet: String = item?.plainSnippet ?: ""
     val enclosure: Enclosure =
         item?.enclosureLink?.let { link ->
             Enclosure(

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleViewModel.kt
@@ -206,8 +206,8 @@ class ArticleViewModel(
                             }
                         } else {
                             Log.e(LOG_TAG, "No default file to parse")
-                            textToDisplay.update { TextToDisplay.FAILED_MISSING_BODY }
-                            LinearArticle(elements = emptyList())
+                            textToDisplay.update { TextToDisplay.CONTENT }
+                            htmlLinearizer.linearize(article.snippet, article.feedUrl ?: "")
                         }
                     }
 


### PR DESCRIPTION
For feed if for some reason cache was cleared.

Ideally, at least the non full article shouldn't be written into the cachedir as it is a key part of the whole "Offline reading" mentioned in Features.

https://developer.android.com/training/data-storage/app-specific#internal-remove-cache
> Caution: When the device is low on internal storage space, Android may delete these cache files to recover space. So check for the existence of your cache files before reading them.

I did accidentally put a huge git repo recently into a syncthing folder which I deleted afterwards and that might had cause the article to get deleted

This hotfix is not ideal but at least it's something, as I doubt it would be possible to retrieve the lost data. screenshot:
![Screenshot_20241208-011326](https://github.com/user-attachments/assets/35bb9f6b-d605-4376-8be6-0709c48821cf)

I would appreciate if you could fix the tag on https://github.com/spacecowboy/Feeder/issues/443 too
Having an situation where the feed get lost ('Found nothing to fetch') is a bug.