### PR TITLE
Build APK for specific architectures

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -107,6 +107,15 @@ android {
 //                signingConfig = signingConfigs.getByName("shareddebug")
 //            }
         }
+
+        splits {
+            abi {
+                isEnable = true
+                reset()
+                include("arm64-v8a", "armeabi-v7a")
+                isUniversalApk = true
+            }
+        }
     }
     testOptions {
         unitTests {


### PR DESCRIPTION
In addition to the universal APK, build specific APK for `arm64-v8a` and `armeabi-v7a` architectures. This allow to download a smaller APK if the device use one of these arch. `x86_64` is used by emulators while `x86` is pretty rare to find (<1% of devices uses this arch) so I excluded them.