### PR TITLE
fix: made feed ordering case insensitive

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/db/room/FeedDao.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/db/room/FeedDao.kt
@@ -63,7 +63,7 @@ interface FeedDao {
 
     @Query(
         """
-        SELECT 
+        SELECT
             id,
             COALESCE(NULLIF(custom_title, ''), title) as title,
             notify
@@ -134,27 +134,27 @@ interface FeedDao {
     @Query(
         """
             -- all items
-            select $ID_ALL_FEEDS as id, '' as display_title, '' as tag, '' as image_url, sum(unread) as unread_count, 0 as expanded, 0 as sort_section, 0 as sort_tag_or_feed
+            select $ID_ALL_FEEDS as id, '' as display_title, '', '' as tag, '' as image_url, sum(unread) as unread_count, 0 as expanded, 0 as sort_section, 0 as sort_tag_or_feed
             from feeds_with_items_for_nav_drawer
             -- starred
             union
-            select $ID_SAVED_ARTICLES as id, '' as display_title, '' as tag, '' as image_url, sum(bookmarked) as unread_count, 0 as expanded, 1 as sort_section, 0 as sort_tag_or_feed
+            select $ID_SAVED_ARTICLES as id, '' as display_title, '', '' as tag, '' as image_url, sum(bookmarked) as unread_count, 0 as expanded, 1 as sort_section, 0 as sort_tag_or_feed
             from feeds_with_items_for_nav_drawer
             where bookmarked
             -- tags
             union
-            select $ID_UNSET as id, tag as display_title, tag, '' as image_url, sum(unread) as unread_count, tag in (:expandedTags) as expanded, 2 as sort_section, 0 as sort_tag_or_feed
+            select $ID_UNSET as id, tag as display_title, '', tag, '' as image_url, sum(unread) as unread_count, tag in (:expandedTags) as expanded, 2 as sort_section, 0 as sort_tag_or_feed
             from feeds_with_items_for_nav_drawer
             where tag is not ''
             group by tag
             -- feeds
             union
-            select feed_id as id, display_title, tag, image_url, sum(unread) as unread_count, 0 as expanded, case when tag is '' then 3 else 2 end as sort_section, 1 as sort_tag_or_feed
+            select feed_id as id, display_title, lower(display_title), tag, image_url, sum(unread) as unread_count, 0 as expanded, case when tag is '' then 3 else 2 end as sort_section, 1 as sort_tag_or_feed
             from feeds_with_items_for_nav_drawer
             where tag is '' or tag in (:expandedTags)
             group by feed_id
             -- sort them
-            order by sort_section, tag, sort_tag_or_feed, display_title
+            order by sort_section, tag, sort_tag_or_feed, lower(display_title)
         """,
     )
     fun getPagedNavDrawerItems(expandedTags: Set<String>): PagingSource<Int, FeedUnreadCount>

--- a/app/src/main/java/com/nononsenseapps/feeder/db/room/FeedDao.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/db/room/FeedDao.kt
@@ -134,27 +134,27 @@ interface FeedDao {
     @Query(
         """
             -- all items
-            select $ID_ALL_FEEDS as id, '' as display_title, '', '' as tag, '' as image_url, sum(unread) as unread_count, 0 as expanded, 0 as sort_section, 0 as sort_tag_or_feed
+            select $ID_ALL_FEEDS as id, '' as display_title, '' as tag, '' as image_url, sum(unread) as unread_count, 0 as expanded, 0 as sort_section, 0 as sort_tag_or_feed
             from feeds_with_items_for_nav_drawer
             -- starred
             union
-            select $ID_SAVED_ARTICLES as id, '' as display_title, '', '' as tag, '' as image_url, sum(bookmarked) as unread_count, 0 as expanded, 1 as sort_section, 0 as sort_tag_or_feed
+            select $ID_SAVED_ARTICLES as id, '' as display_title, '' as tag, '' as image_url, sum(bookmarked) as unread_count, 0 as expanded, 1 as sort_section, 0 as sort_tag_or_feed
             from feeds_with_items_for_nav_drawer
             where bookmarked
             -- tags
             union
-            select $ID_UNSET as id, tag as display_title, '', tag, '' as image_url, sum(unread) as unread_count, tag in (:expandedTags) as expanded, 2 as sort_section, 0 as sort_tag_or_feed
+            select $ID_UNSET as id, tag as display_title, tag, '' as image_url, sum(unread) as unread_count, tag in (:expandedTags) as expanded, 2 as sort_section, 0 as sort_tag_or_feed
             from feeds_with_items_for_nav_drawer
             where tag is not ''
             group by tag
             -- feeds
             union
-            select feed_id as id, display_title, lower(display_title), tag, image_url, sum(unread) as unread_count, 0 as expanded, case when tag is '' then 3 else 2 end as sort_section, 1 as sort_tag_or_feed
+            select feed_id as id, display_title, tag, image_url, sum(unread) as unread_count, 0 as expanded, case when tag is '' then 3 else 2 end as sort_section, 1 as sort_tag_or_feed
             from feeds_with_items_for_nav_drawer
             where tag is '' or tag in (:expandedTags)
             group by feed_id
             -- sort them
-            order by sort_section, tag, sort_tag_or_feed, lower(display_title)
+            order by sort_section, tag, sort_tag_or_feed, display_title collate nocase
         """,
     )
     fun getPagedNavDrawerItems(expandedTags: Set<String>): PagingSource<Int, FeedUnreadCount>


### PR DESCRIPTION
Properly sorts the feeds in the sidebar, ignoring case.
Not applied to tags for now, because these are user-defined. <!-- `lower(tags), tags` -->
Is this a feature you'd consider including?