### PR TITLE
fix: moved articles (not full) out of cache dir to avoid Android deleting them

### DIFF
--- a/app/schemas/com.nononsenseapps.feeder.db.room.AppDatabase/37.json
+++ b/app/schemas/com.nononsenseapps.feeder.db.room.AppDatabase/37.json
@@ -1,0 +1,773 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 37,
+    "identityHash": "43da8b324027c3b7d184427319dc32a0",
+    "entities": [
+      {
+        "tableName": "feeds",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `custom_title` TEXT NOT NULL, `url` TEXT NOT NULL, `tag` TEXT NOT NULL, `notify` INTEGER NOT NULL, `image_url` TEXT, `last_sync` INTEGER NOT NULL, `response_hash` INTEGER NOT NULL, `fulltext_by_default` INTEGER NOT NULL, `open_articles_with` TEXT NOT NULL, `alternate_id` INTEGER NOT NULL, `currently_syncing` INTEGER NOT NULL, `when_modified` INTEGER NOT NULL, `site_fetched` INTEGER NOT NULL, `skip_duplicates` INTEGER NOT NULL, `retry_after` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customTitle",
+            "columnName": "custom_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notify",
+            "columnName": "notify",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastSync",
+            "columnName": "last_sync",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "responseHash",
+            "columnName": "response_hash",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullTextByDefault",
+            "columnName": "fulltext_by_default",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openArticlesWith",
+            "columnName": "open_articles_with",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alternateId",
+            "columnName": "alternate_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentlySyncing",
+            "columnName": "currently_syncing",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "whenModified",
+            "columnName": "when_modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siteFetched",
+            "columnName": "site_fetched",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skipDuplicates",
+            "columnName": "skip_duplicates",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "retryAfter",
+            "columnName": "retry_after",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feeds_url",
+            "unique": true,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_feeds_url` ON `${TABLE_NAME}` (`url`)"
+          },
+          {
+            "name": "index_feeds_id_url_title",
+            "unique": true,
+            "columnNames": [
+              "id",
+              "url",
+              "title"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_feeds_id_url_title` ON `${TABLE_NAME}` (`id`, `url`, `title`)"
+          }
+        ]
+      },
+      {
+        "tableName": "feed_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `guid` TEXT NOT NULL, `title` TEXT NOT NULL, `plain_title` TEXT NOT NULL, `plain_snippet` TEXT NOT NULL, `image_url` TEXT, `image_from_body` INTEGER NOT NULL, `enclosure_link` TEXT, `enclosure_type` TEXT, `author` TEXT, `pub_date` TEXT, `link` TEXT, `unread` INTEGER NOT NULL, `notified` INTEGER NOT NULL, `feed_id` INTEGER, `first_synced_time` INTEGER NOT NULL, `primary_sort_time` INTEGER NOT NULL, `pinned` INTEGER NOT NULL, `bookmarked` INTEGER NOT NULL, `fulltext_downloaded` INTEGER NOT NULL, `read_time` INTEGER, `word_count` INTEGER NOT NULL, `word_count_full` INTEGER NOT NULL, `block_time` INTEGER, FOREIGN KEY(`feed_id`) REFERENCES `feeds`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "guid",
+            "columnName": "guid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "plainTitle",
+            "columnName": "plain_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "plainSnippet",
+            "columnName": "plain_snippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailImage",
+            "columnName": "image_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageFromBody",
+            "columnName": "image_from_body",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enclosureLink",
+            "columnName": "enclosure_link",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "enclosureType",
+            "columnName": "enclosure_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pubDate",
+            "columnName": "pub_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "link",
+            "columnName": "link",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "oldUnread",
+            "columnName": "unread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notified",
+            "columnName": "notified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedId",
+            "columnName": "feed_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "firstSyncedTime",
+            "columnName": "first_synced_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "primarySortTime",
+            "columnName": "primary_sort_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "oldPinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarked",
+            "columnName": "bookmarked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullTextDownloaded",
+            "columnName": "fulltext_downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readTime",
+            "columnName": "read_time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "wordCount",
+            "columnName": "word_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wordCountFull",
+            "columnName": "word_count_full",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "blockTime",
+            "columnName": "block_time",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_items_guid_feed_id",
+            "unique": true,
+            "columnNames": [
+              "guid",
+              "feed_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_feed_items_guid_feed_id` ON `${TABLE_NAME}` (`guid`, `feed_id`)"
+          },
+          {
+            "name": "index_feed_items_feed_id",
+            "unique": false,
+            "columnNames": [
+              "feed_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_items_feed_id` ON `${TABLE_NAME}` (`feed_id`)"
+          },
+          {
+            "name": "index_feed_items_block_time",
+            "unique": false,
+            "columnNames": [
+              "block_time"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_items_block_time` ON `${TABLE_NAME}` (`block_time`)"
+          },
+          {
+            "name": "idx_feed_items_cursor",
+            "unique": true,
+            "columnNames": [
+              "primary_sort_time",
+              "pub_date",
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `idx_feed_items_cursor` ON `${TABLE_NAME}` (`primary_sort_time`, `pub_date`, `id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "feeds",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "feed_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "blocklist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `glob_pattern` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "globPattern",
+            "columnName": "glob_pattern",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_blocklist_glob_pattern",
+            "unique": true,
+            "columnNames": [
+              "glob_pattern"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_blocklist_glob_pattern` ON `${TABLE_NAME}` (`glob_pattern`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_remote",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `url` TEXT NOT NULL, `sync_chain_id` TEXT NOT NULL, `latest_message_timestamp` INTEGER NOT NULL, `device_id` INTEGER NOT NULL, `device_name` TEXT NOT NULL, `secret_key` TEXT NOT NULL, `last_feeds_remote_hash` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncChainId",
+            "columnName": "sync_chain_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latestMessageTimestamp",
+            "columnName": "latest_message_timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceName",
+            "columnName": "device_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "secretKey",
+            "columnName": "secret_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastFeedsRemoteHash",
+            "columnName": "last_feeds_remote_hash",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "read_status_synced",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sync_remote` INTEGER NOT NULL, `feed_item` INTEGER NOT NULL, FOREIGN KEY(`feed_item`) REFERENCES `feed_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`sync_remote`) REFERENCES `sync_remote`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sync_remote",
+            "columnName": "sync_remote",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feed_item",
+            "columnName": "feed_item",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_read_status_synced_feed_item_sync_remote",
+            "unique": true,
+            "columnNames": [
+              "feed_item",
+              "sync_remote"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_read_status_synced_feed_item_sync_remote` ON `${TABLE_NAME}` (`feed_item`, `sync_remote`)"
+          },
+          {
+            "name": "index_read_status_synced_feed_item",
+            "unique": false,
+            "columnNames": [
+              "feed_item"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_read_status_synced_feed_item` ON `${TABLE_NAME}` (`feed_item`)"
+          },
+          {
+            "name": "index_read_status_synced_sync_remote",
+            "unique": false,
+            "columnNames": [
+              "sync_remote"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_read_status_synced_sync_remote` ON `${TABLE_NAME}` (`sync_remote`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "feed_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "feed_item"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sync_remote",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sync_remote"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "remote_read_mark",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sync_remote` INTEGER NOT NULL, `feed_url` TEXT NOT NULL, `guid` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, FOREIGN KEY(`sync_remote`) REFERENCES `sync_remote`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sync_remote",
+            "columnName": "sync_remote",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedUrl",
+            "columnName": "feed_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "guid",
+            "columnName": "guid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_remote_read_mark_sync_remote_feed_url_guid",
+            "unique": true,
+            "columnNames": [
+              "sync_remote",
+              "feed_url",
+              "guid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_remote_read_mark_sync_remote_feed_url_guid` ON `${TABLE_NAME}` (`sync_remote`, `feed_url`, `guid`)"
+          },
+          {
+            "name": "index_remote_read_mark_feed_url_guid",
+            "unique": false,
+            "columnNames": [
+              "feed_url",
+              "guid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_remote_read_mark_feed_url_guid` ON `${TABLE_NAME}` (`feed_url`, `guid`)"
+          },
+          {
+            "name": "index_remote_read_mark_sync_remote",
+            "unique": false,
+            "columnNames": [
+              "sync_remote"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_remote_read_mark_sync_remote` ON `${TABLE_NAME}` (`sync_remote`)"
+          },
+          {
+            "name": "index_remote_read_mark_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_remote_read_mark_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sync_remote",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sync_remote"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "remote_feed",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sync_remote` INTEGER NOT NULL, `url` TEXT NOT NULL, FOREIGN KEY(`sync_remote`) REFERENCES `sync_remote`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncRemote",
+            "columnName": "sync_remote",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_remote_feed_sync_remote_url",
+            "unique": true,
+            "columnNames": [
+              "sync_remote",
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_remote_feed_sync_remote_url` ON `${TABLE_NAME}` (`sync_remote`, `url`)"
+          },
+          {
+            "name": "index_remote_feed_url",
+            "unique": false,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_remote_feed_url` ON `${TABLE_NAME}` (`url`)"
+          },
+          {
+            "name": "index_remote_feed_sync_remote",
+            "unique": false,
+            "columnNames": [
+              "sync_remote"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_remote_feed_sync_remote` ON `${TABLE_NAME}` (`sync_remote`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sync_remote",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sync_remote"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_device",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sync_remote` INTEGER NOT NULL, `device_id` INTEGER NOT NULL, `device_name` TEXT NOT NULL, FOREIGN KEY(`sync_remote`) REFERENCES `sync_remote`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncRemote",
+            "columnName": "sync_remote",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceName",
+            "columnName": "device_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_device_sync_remote_device_id",
+            "unique": true,
+            "columnNames": [
+              "sync_remote",
+              "device_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sync_device_sync_remote_device_id` ON `${TABLE_NAME}` (`sync_remote`, `device_id`)"
+          },
+          {
+            "name": "index_sync_device_sync_remote",
+            "unique": false,
+            "columnNames": [
+              "sync_remote"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_device_sync_remote` ON `${TABLE_NAME}` (`sync_remote`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sync_remote",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sync_remote"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [
+      {
+        "viewName": "feeds_with_items_for_nav_drawer",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS select feeds.id as feed_id, item_id, case when custom_title is '' then title else custom_title end as display_title, tag, image_url, unread, bookmarked\n    from feeds\n    left join (\n        select id as item_id, feed_id, read_time is null as unread, bookmarked\n        from feed_items\n        where block_time is null\n    )\n    ON feeds.id = feed_id"
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '43da8b324027c3b7d184427319dc32a0')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/nononsenseapps/feeder/db/room/TestMigrationFrom36To37.kt
+++ b/app/src/androidTest/java/com/nononsenseapps/feeder/db/room/TestMigrationFrom36To37.kt
@@ -29,6 +29,7 @@ class TestMigrationFrom36To37 : DIAware {
     override val di: DI by closestDI(feederApplication)
     private val filePathProvider: FilePathProvider by instance()
     private val oldDir = File(feederApplication.cacheDir, "articles")
+    private val newDir = File(feederApplication.filesDir, "articles")
 
     @Rule
     @JvmField
@@ -42,7 +43,9 @@ class TestMigrationFrom36To37 : DIAware {
 
     @Before
     fun setUp() {
+        oldDir.deleteRecursively()
         oldDir.mkdirs()
+        newDir.deleteRecursively()
     }
 
     @After
@@ -77,8 +80,6 @@ class TestMigrationFrom36To37 : DIAware {
             true,
             MigrationFrom36To37(di),
         )
-
-        val newDir = feederApplication.filesDir.resolve("articles")
 
         assertTrue {
             newDir.resolve(name1).isFile

--- a/app/src/androidTest/java/com/nononsenseapps/feeder/db/room/TestMigrationFrom36To37.kt
+++ b/app/src/androidTest/java/com/nononsenseapps/feeder/db/room/TestMigrationFrom36To37.kt
@@ -1,6 +1,5 @@
 package com.nononsenseapps.feeder.db.room
 
-import android.util.Log
 import androidx.room.testing.MigrationTestHelper
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import androidx.test.core.app.ApplicationProvider
@@ -29,7 +28,7 @@ class TestMigrationFrom36To37 : DIAware {
     private val feederApplication: FeederApplication = ApplicationProvider.getApplicationContext()
     override val di: DI by closestDI(feederApplication)
     private val filePathProvider: FilePathProvider by instance()
-    private val tempOldArticleDir = File(feederApplication.filesDir, "testOldArticles")
+    private val oldDir = File(feederApplication.cacheDir, "articles")
 
     @Rule
     @JvmField
@@ -43,100 +42,59 @@ class TestMigrationFrom36To37 : DIAware {
 
     @Before
     fun setUp() {
-        // Create a temporary old article directory
-        tempOldArticleDir.mkdirs()
-
-        // Create article directory if it doesn't exist
-        filePathProvider.articleDir.mkdirs()
-
-        // Clean any existing test files
-        filePathProvider.articleDir.listFiles()?.forEach { it.delete() }
+        oldDir.mkdirs()
     }
 
     @After
     fun tearDown() {
         // Clean up test files
-        tempOldArticleDir.deleteRecursively()
+        oldDir.deleteRecursively()
+        filePathProvider.articleDir.deleteRecursively()
     }
 
     @Test
     fun migrate_validFilesAreMoved_invalidFilesAreDeleted() {
         // First, set up the database with some feed item records
-        @Suppress("SimpleRedundantLet")
-        testHelper.createDatabase(dbName, FROM_VERSION).let { oldDB ->
-            // Create a valid feed item
-            oldDB.execSQL(
-                """
-                INSERT INTO feeds(id, title, url, custom_title, tag, notify, last_sync, response_hash, fulltext_by_default, open_articles_with, alternate_id, currently_syncing, when_modified, site_fetched, skip_duplicates, retry_after)
-                VALUES(1, 'feed', 'http://url', '', '', 0, 0, 666, 0, '', 0, 0, 0, 0, 0, 0)
-                """.trimIndent(),
-            )
+        testHelper.createDatabase(dbName, FROM_VERSION).close()
 
-            oldDB.execSQL(
-                """
-                INSERT INTO feed_items(id, guid, title, plain_title, plain_snippet, feed_id)
-                VALUES(101, 'guid1', 'title1', 'plaintitle1', 'snippet1', 1)
-                """.trimIndent(),
-            )
+        // Test files here
+        val name1 = "1.txt.gz"
+        val name2 = "2.txt.gz"
 
-            oldDB.execSQL(
-                """
-                INSERT INTO feed_items(id, guid, title, plain_title, plain_snippet, feed_id)
-                VALUES(102, 'guid2', 'title2', 'plaintitle2', 'snippet2', 1)
-                """.trimIndent(),
-            )
+        val oldDir = feederApplication.cacheDir.resolve("articles")
 
-            oldDB.close()
+        assertTrue {
+            oldDir.resolve(name1).createNewFile()
         }
 
-        // Create test files in the old article directory
-        // Valid files - should be migrated
-        File(tempOldArticleDir, "101.txt.gz").createNewFile()
-        File(tempOldArticleDir, "102.txt.gz").createNewFile()
+        assertTrue {
+            oldDir.resolve(name2).createNewFile()
+        }
 
-        // Invalid files - should be deleted
-        File(tempOldArticleDir, "999.txt.gz").createNewFile() // ID doesn't exist in DB
-        File(tempOldArticleDir, "invalid.txt.gz").createNewFile() // Not a valid ID format
-
-        // Patch the migration to use our temp directory instead of the actual oldArticleDir
-        val testMigration =
-            object : MigrationFrom36To37(di) {
-                override fun migrate(database: androidx.sqlite.db.SupportSQLiteDatabase) {
-                    Log.i("TEST_MIGRATION", "Starting test migration")
-                    try {
-                        // Get all valid feed item IDs from the database
-                        val validFeedItemIds = feedItemDao.getAllFeedItemIds()
-
-                        // Ensure target directory exists
-                        if (!filePathProvider.articleDir.exists()) {
-                            filePathProvider.articleDir.mkdirs()
-                        }
-
-                        // Migrate files from the temp directory instead of oldArticleDir
-                        migrateFiles(tempOldArticleDir, filePathProvider.articleDir, validFeedItemIds)
-
-                        Log.i("TEST_MIGRATION", "Completed test migration")
-                    } catch (e: Exception) {
-                        Log.e("TEST_MIGRATION", "Error during test migration", e)
-                    }
-                }
-            }
-
-        // Run the migration
         testHelper.runMigrationsAndValidate(
             dbName,
             TO_VERSION,
             true,
-            testMigration,
+            MigrationFrom36To37(di),
         )
 
-        // Verify that valid files were migrated to the article directory
-        assertTrue(File(filePathProvider.articleDir, "101.txt.gz").exists(), "Valid file 101.txt.gz should be migrated")
-        assertTrue(File(filePathProvider.articleDir, "102.txt.gz").exists(), "Valid file 102.txt.gz should be migrated")
+        val newDir = feederApplication.filesDir.resolve("articles")
 
-        // Verify that invalid files were deleted from the old article directory
-        assertFalse(File(tempOldArticleDir, "999.txt.gz").exists(), "Invalid file 999.txt.gz should be deleted")
-        assertFalse(File(tempOldArticleDir, "invalid.txt.gz").exists(), "Invalid file invalid.txt.gz should be deleted")
+        assertTrue {
+            newDir.resolve(name1).isFile
+        }
+
+        assertTrue {
+            newDir.resolve(name2).isFile
+        }
+
+        assertFalse {
+            oldDir.resolve(name1).isFile
+        }
+
+        assertFalse {
+            oldDir.resolve(name2).isFile
+        }
     }
 
     companion object {

--- a/app/src/androidTest/java/com/nononsenseapps/feeder/db/room/TestMigrationFrom36To37.kt
+++ b/app/src/androidTest/java/com/nononsenseapps/feeder/db/room/TestMigrationFrom36To37.kt
@@ -1,0 +1,146 @@
+package com.nononsenseapps.feeder.db.room
+
+import android.util.Log
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import com.nononsenseapps.feeder.FeederApplication
+import com.nononsenseapps.feeder.util.FilePathProvider
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.kodein.di.DI
+import org.kodein.di.DIAware
+import org.kodein.di.android.closestDI
+import org.kodein.di.instance
+import java.io.File
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class TestMigrationFrom36To37 : DIAware {
+    private val dbName = "testDb"
+    private val feederApplication: FeederApplication = ApplicationProvider.getApplicationContext()
+    override val di: DI by closestDI(feederApplication)
+    private val filePathProvider: FilePathProvider by instance()
+    private val tempOldArticleDir = File(feederApplication.filesDir, "testOldArticles")
+
+    @Rule
+    @JvmField
+    val testHelper: MigrationTestHelper =
+        MigrationTestHelper(
+            InstrumentationRegistry.getInstrumentation(),
+            AppDatabase::class.java,
+            emptyList(),
+            FrameworkSQLiteOpenHelperFactory(),
+        )
+
+    @Before
+    fun setUp() {
+        // Create a temporary old article directory
+        tempOldArticleDir.mkdirs()
+
+        // Create article directory if it doesn't exist
+        filePathProvider.articleDir.mkdirs()
+
+        // Clean any existing test files
+        filePathProvider.articleDir.listFiles()?.forEach { it.delete() }
+    }
+
+    @After
+    fun tearDown() {
+        // Clean up test files
+        tempOldArticleDir.deleteRecursively()
+    }
+
+    @Test
+    fun migrate_validFilesAreMoved_invalidFilesAreDeleted() {
+        // First, set up the database with some feed item records
+        @Suppress("SimpleRedundantLet")
+        testHelper.createDatabase(dbName, FROM_VERSION).let { oldDB ->
+            // Create a valid feed item
+            oldDB.execSQL(
+                """
+                INSERT INTO feeds(id, title, url, custom_title, tag, notify, last_sync, response_hash, fulltext_by_default, open_articles_with, alternate_id, currently_syncing, when_modified, site_fetched, skip_duplicates, retry_after)
+                VALUES(1, 'feed', 'http://url', '', '', 0, 0, 666, 0, '', 0, 0, 0, 0, 0, 0)
+                """.trimIndent(),
+            )
+
+            oldDB.execSQL(
+                """
+                INSERT INTO feed_items(id, guid, title, plain_title, plain_snippet, feed_id)
+                VALUES(101, 'guid1', 'title1', 'plaintitle1', 'snippet1', 1)
+                """.trimIndent(),
+            )
+
+            oldDB.execSQL(
+                """
+                INSERT INTO feed_items(id, guid, title, plain_title, plain_snippet, feed_id)
+                VALUES(102, 'guid2', 'title2', 'plaintitle2', 'snippet2', 1)
+                """.trimIndent(),
+            )
+
+            oldDB.close()
+        }
+
+        // Create test files in the old article directory
+        // Valid files - should be migrated
+        File(tempOldArticleDir, "101.txt.gz").createNewFile()
+        File(tempOldArticleDir, "102.txt.gz").createNewFile()
+
+        // Invalid files - should be deleted
+        File(tempOldArticleDir, "999.txt.gz").createNewFile() // ID doesn't exist in DB
+        File(tempOldArticleDir, "invalid.txt.gz").createNewFile() // Not a valid ID format
+
+        // Patch the migration to use our temp directory instead of the actual oldArticleDir
+        val testMigration =
+            object : MigrationFrom36To37(di) {
+                override fun migrate(database: androidx.sqlite.db.SupportSQLiteDatabase) {
+                    Log.i("TEST_MIGRATION", "Starting test migration")
+                    try {
+                        // Get all valid feed item IDs from the database
+                        val validFeedItemIds = feedItemDao.getAllFeedItemIds()
+
+                        // Ensure target directory exists
+                        if (!filePathProvider.articleDir.exists()) {
+                            filePathProvider.articleDir.mkdirs()
+                        }
+
+                        // Migrate files from the temp directory instead of oldArticleDir
+                        migrateFiles(tempOldArticleDir, filePathProvider.articleDir, validFeedItemIds)
+
+                        Log.i("TEST_MIGRATION", "Completed test migration")
+                    } catch (e: Exception) {
+                        Log.e("TEST_MIGRATION", "Error during test migration", e)
+                    }
+                }
+            }
+
+        // Run the migration
+        testHelper.runMigrationsAndValidate(
+            dbName,
+            TO_VERSION,
+            true,
+            testMigration,
+        )
+
+        // Verify that valid files were migrated to the article directory
+        assertTrue(File(filePathProvider.articleDir, "101.txt.gz").exists(), "Valid file 101.txt.gz should be migrated")
+        assertTrue(File(filePathProvider.articleDir, "102.txt.gz").exists(), "Valid file 102.txt.gz should be migrated")
+
+        // Verify that invalid files were deleted from the old article directory
+        assertFalse(File(tempOldArticleDir, "999.txt.gz").exists(), "Invalid file 999.txt.gz should be deleted")
+        assertFalse(File(tempOldArticleDir, "invalid.txt.gz").exists(), "Invalid file invalid.txt.gz should be deleted")
+    }
+
+    companion object {
+        private const val FROM_VERSION = 36
+        private const val TO_VERSION = 37
+    }
+}

--- a/app/src/main/java/com/nononsenseapps/feeder/background/BackgroundJobId.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/background/BackgroundJobId.kt
@@ -11,6 +11,7 @@ enum class BackgroundJobId(
     SYNC_CHAIN_GET_UPDATES(4),
     SYNC_CHAIN_SEND_READ(5),
     BLOCKLIST_UPDATE(6),
+    CLEANUP_ORPHANED_FILES(7),
 }
 
 interface BackgroundJob {

--- a/app/src/main/java/com/nononsenseapps/feeder/background/CleanupOrphanedFilesJob.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/background/CleanupOrphanedFilesJob.kt
@@ -46,9 +46,6 @@ class CleanupOrphanedFilesJob(
             // Clean up article files in articleDir
             cleanupDirectory(filePathProvider.articleDir, validFeedItemIds, ::blobFile)
 
-            // Clean up article files in oldArticleDir
-            cleanupDirectory(filePathProvider.oldArticleDir, validFeedItemIds, ::blobFile)
-
             // Clean up full article files in fullArticleDir
             cleanupDirectory(filePathProvider.fullArticleDir, validFeedItemIds, ::blobFullFile)
 

--- a/app/src/main/java/com/nononsenseapps/feeder/background/CleanupOrphanedFilesJob.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/background/CleanupOrphanedFilesJob.kt
@@ -1,0 +1,137 @@
+package com.nononsenseapps.feeder.background
+
+import android.app.Application
+import android.app.job.JobInfo
+import android.app.job.JobParameters
+import android.app.job.JobScheduler
+import android.content.ComponentName
+import android.content.Context
+import android.util.Log
+import androidx.core.content.getSystemService
+import com.nononsenseapps.feeder.blob.blobFile
+import com.nononsenseapps.feeder.blob.blobFullFile
+import com.nononsenseapps.feeder.db.room.FeedItemDao
+import com.nononsenseapps.feeder.util.FilePathProvider
+import com.nononsenseapps.feeder.util.logDebug
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.kodein.di.DI
+import org.kodein.di.DIAware
+import org.kodein.di.android.closestDI
+import org.kodein.di.instance
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+class CleanupOrphanedFilesJob(
+    context: Context,
+    override val params: JobParameters,
+) : BackgroundJob, DIAware {
+    override val di: DI by closestDI(context)
+
+    private val filePathProvider: FilePathProvider by instance()
+    private val feedItemDao: FeedItemDao by instance()
+
+    override val jobId: Int = params.jobId
+
+    override suspend fun doWork() {
+        try {
+            Log.i(LOG_TAG, "Starting cleanup of orphaned article files")
+
+            // Get all valid feed item IDs from the database
+            val validFeedItemIds =
+                withContext(Dispatchers.IO) {
+                    feedItemDao.getAllFeedItemIds()
+                }
+
+            // Clean up article files in articleDir
+            cleanupDirectory(filePathProvider.articleDir, validFeedItemIds, ::blobFile)
+
+            // Clean up article files in oldArticleDir
+            cleanupDirectory(filePathProvider.oldArticleDir, validFeedItemIds, ::blobFile)
+
+            // Clean up full article files in fullArticleDir
+            cleanupDirectory(filePathProvider.fullArticleDir, validFeedItemIds, ::blobFullFile)
+
+            Log.i(LOG_TAG, "Completed cleanup of orphaned article files")
+        } catch (e: Exception) {
+            Log.e(LOG_TAG, "Error during cleanup of orphaned files", e)
+        }
+    }
+
+    private suspend fun cleanupDirectory(
+        directory: File,
+        validIds: List<Long>,
+        fileProvider: (Long, File) -> File,
+    ) {
+        if (!directory.isDirectory) {
+            logDebug(LOG_TAG, "Directory doesn't exist: ${directory.absolutePath}")
+            return
+        }
+
+        val validFilePaths =
+            validIds.map { id ->
+                fileProvider(id, directory).canonicalPath
+            }.toSet()
+
+        var deletedCount = 0
+        withContext(Dispatchers.IO) {
+            directory.listFiles()?.forEach { file ->
+                try {
+                    val filePath = file.canonicalPath
+                    if (!validFilePaths.contains(filePath)) {
+                        if (file.delete()) {
+                            deletedCount++
+                            logDebug(LOG_TAG, "Deleted orphaned file: $filePath")
+                        } else {
+                            Log.w(LOG_TAG, "Failed to delete orphaned file: $filePath")
+                        }
+                    }
+                } catch (e: Exception) {
+                    Log.e(LOG_TAG, "Error processing file ${file.canonicalPath}", e)
+                }
+            }
+        }
+
+        Log.i(LOG_TAG, "Deleted $deletedCount orphaned files from ${directory.canonicalPath}")
+    }
+
+    companion object {
+        const val LOG_TAG = "FEEDER_CLEANUP_FILES"
+    }
+}
+
+fun schedulePeriodicOrphanedFilesCleanup(di: DI) {
+    val context: Application by di.instance()
+    val jobScheduler: JobScheduler? = context.getSystemService()
+
+    if (jobScheduler == null) {
+        Log.e(CleanupOrphanedFilesJob.LOG_TAG, "JobScheduler not available")
+        return
+    }
+
+    // Get current job if exists
+    val currentJob = jobScheduler.getMyPendingJob(BackgroundJobId.CLEANUP_ORPHANED_FILES.jobId)
+
+    // Only schedule if the job doesn't exist yet
+    if (currentJob == null) {
+        val componentName = ComponentName(context, FeederJobService::class.java)
+
+        // Schedule to run once per day (24 hours)
+        val dailyIntervalMillis = TimeUnit.DAYS.toMillis(1)
+
+        val jobInfo =
+            JobInfo.Builder(BackgroundJobId.CLEANUP_ORPHANED_FILES.jobId, componentName)
+                // Run when device is idle
+                .setRequiresDeviceIdle(true)
+                // Run when device is charging
+                .setRequiresCharging(true)
+                // Set periodic interval to one day
+                .setPeriodic(dailyIntervalMillis)
+                // Persist across reboots
+                .setPersisted(true)
+                .build()
+
+        jobScheduler.schedule(jobInfo)
+        Log.i(CleanupOrphanedFilesJob.LOG_TAG, "Scheduled daily cleanup of orphaned files")
+    }
+}

--- a/app/src/main/java/com/nononsenseapps/feeder/background/CleanupOrphanedFilesJob.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/background/CleanupOrphanedFilesJob.kt
@@ -25,7 +25,8 @@ import java.util.concurrent.TimeUnit
 class CleanupOrphanedFilesJob(
     context: Context,
     override val params: JobParameters,
-) : BackgroundJob, DIAware {
+) : BackgroundJob,
+    DIAware {
     override val di: DI by closestDI(context)
 
     private val filePathProvider: FilePathProvider by instance()
@@ -66,9 +67,10 @@ class CleanupOrphanedFilesJob(
         }
 
         val validFilePaths =
-            validIds.map { id ->
-                fileProvider(id, directory).canonicalPath
-            }.toSet()
+            validIds
+                .map { id ->
+                    fileProvider(id, directory).canonicalPath
+                }.toSet()
 
         var deletedCount = 0
         withContext(Dispatchers.IO) {
@@ -117,7 +119,8 @@ fun schedulePeriodicOrphanedFilesCleanup(di: DI) {
         val dailyIntervalMillis = TimeUnit.DAYS.toMillis(1)
 
         val jobInfo =
-            JobInfo.Builder(BackgroundJobId.CLEANUP_ORPHANED_FILES.jobId, componentName)
+            JobInfo
+                .Builder(BackgroundJobId.CLEANUP_ORPHANED_FILES.jobId, componentName)
                 // Run when device is idle
                 .setRequiresDeviceIdle(true)
                 // Run when device is charging

--- a/app/src/main/java/com/nononsenseapps/feeder/background/FeederJobService.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/background/FeederJobService.kt
@@ -58,6 +58,9 @@ class FeederJobService : DIAwareJobService() {
             BackgroundJobId.BLOCKLIST_UPDATE.jobId -> {
                 runJob(BlocklistUpdateJob(context = this, params = params))
             }
+            BackgroundJobId.CLEANUP_ORPHANED_FILES.jobId -> {
+                runJob(CleanupOrphanedFilesJob(context = this, params = params))
+            }
             else -> {
                 Log.i(LOG_TAG, "Unknown job id: ${params.jobId}")
                 false

--- a/app/src/main/java/com/nononsenseapps/feeder/background/SyncChainSendReadJob.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/background/SyncChainSendReadJob.kt
@@ -54,7 +54,7 @@ fun runOnceSyncChainSendRead(di: DI) {
     val context: Application by di.instance()
 
     if (!repository.isSyncChainConfigured) {
-        Log.e(SyncChainSendReadJob.LOG_TAG, "Sync chain not enabled")
+        // Not an error, just means that sync chain is not configured
         return
     }
 

--- a/app/src/main/java/com/nononsenseapps/feeder/db/room/AppDatabase.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/db/room/AppDatabase.kt
@@ -168,18 +168,19 @@ class MigrationFrom36To37(
                 Log.i(LOG_TAG, "Source directory does not exist: ${srcDir.absolutePath}")
                 return
             }
-            srcDir.list { _, name ->
-                name.endsWith(".txt.gz")
-            }?.forEach { name ->
-                try {
-                    val src = srcDir.resolve(name)
-                    val dst = filePathProvider.articleDir.resolve(name)
+            srcDir
+                .list { _, name ->
+                    name.endsWith(".txt.gz")
+                }?.forEach { name ->
+                    try {
+                        val src = srcDir.resolve(name)
+                        val dst = filePathProvider.articleDir.resolve(name)
 
-                    src.renameTo(dst)
-                } catch (t: Throwable) {
-                    Log.e(LOG_TAG, "Failed to delete: $name", t)
+                        src.renameTo(dst)
+                    } catch (t: Throwable) {
+                        Log.e(LOG_TAG, "Failed to delete: $name", t)
+                    }
                 }
-            }
 
             Log.i(LOG_TAG, "Completed migration of article files")
         } catch (e: Exception) {

--- a/app/src/main/java/com/nononsenseapps/feeder/db/room/AppDatabase.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/db/room/AppDatabase.kt
@@ -163,7 +163,6 @@ class MigrationFrom36To37(
                 dstDir.mkdirs()
             }
 
-            // Migrate files from oldArticleDir to articleDir
             val srcDir = filePathProvider.cacheDir.resolve("articles")
             if (!srcDir.isDirectory) {
                 Log.i(LOG_TAG, "Source directory does not exist: ${srcDir.absolutePath}")

--- a/app/src/main/java/com/nononsenseapps/feeder/db/room/AppDatabase.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/db/room/AppDatabase.kt
@@ -158,8 +158,9 @@ class MigrationFrom36To37(
 
         try {
             // Ensure target directory exists
-            if (!filePathProvider.articleDir.exists()) {
-                filePathProvider.articleDir.mkdirs()
+            val dstDir = filePathProvider.filesDir.resolve("articles")
+            if (!dstDir.exists()) {
+                dstDir.mkdirs()
             }
 
             // Migrate files from oldArticleDir to articleDir
@@ -174,7 +175,7 @@ class MigrationFrom36To37(
                 }?.forEach { name ->
                     try {
                         val src = srcDir.resolve(name)
-                        val dst = filePathProvider.articleDir.resolve(name)
+                        val dst = dstDir.resolve(name)
 
                         src.renameTo(dst)
                     } catch (t: Throwable) {
@@ -376,7 +377,7 @@ class MigrationFrom24To25(
                 try {
                     filePathProvider.filesDir.resolve(name).delete()
                 } catch (t: Throwable) {
-                    Log.e(LOG_TAG, "Failed to delete: $name")
+                    Log.e(LOG_TAG, "Failed to delete: $name", t)
                 }
             }
 
@@ -387,15 +388,15 @@ class MigrationFrom24To25(
             }?.forEach { name ->
                 try {
                     val src = filePathProvider.filesDir.resolve(name)
-                    val dst = filePathProvider.articleDir.resolve(name)
+                    val dst = filePathProvider.cacheDir.resolve("articles").resolve(name)
 
-                    if (!filePathProvider.articleDir.isDirectory) {
-                        filePathProvider.articleDir.mkdirs()
+                    if (!filePathProvider.cacheDir.resolve("articles").isDirectory) {
+                        filePathProvider.cacheDir.resolve("articles").mkdirs()
                     }
 
                     src.renameTo(dst)
                 } catch (t: Throwable) {
-                    Log.e(LOG_TAG, "Failed to delete: $name")
+                    Log.e(LOG_TAG, "Failed to delete: $name", t)
                 }
             }
     }

--- a/app/src/main/java/com/nononsenseapps/feeder/db/room/AppDatabase.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/db/room/AppDatabase.kt
@@ -164,6 +164,10 @@ class MigrationFrom36To37(
 
             // Migrate files from oldArticleDir to articleDir
             val srcDir = filePathProvider.cacheDir.resolve("articles")
+            if (!srcDir.isDirectory) {
+                Log.i(LOG_TAG, "Source directory does not exist: ${srcDir.absolutePath}")
+                return
+            }
             srcDir.list { _, name ->
                 name.endsWith(".txt.gz")
             }?.forEach { name ->

--- a/app/src/main/java/com/nononsenseapps/feeder/db/room/FeedItemDao.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/db/room/FeedItemDao.kt
@@ -502,6 +502,9 @@ interface FeedItemDao {
         link: String?,
     ): Boolean
 
+    @Query("SELECT id FROM feed_items")
+    suspend fun getAllFeedItemIds(): List<Long>
+
     companion object {
         // These are backed by a database index
         const val FEED_ITEM_LIST_SORT_ORDER_DESC =

--- a/app/src/main/java/com/nononsenseapps/feeder/model/RssLocalSync.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/RssLocalSync.kt
@@ -429,6 +429,16 @@ class RssLocalSync(
                         }
                         Unit
                     }
+                    blobFile(itemId = id, filesDir = filePathProvider.oldArticleDir).let { file ->
+                        try {
+                            if (file.isFile) {
+                                file.delete()
+                            }
+                        } catch (e: IOException) {
+                            Log.e(LOG_TAG, "Failed to delete $file", e)
+                        }
+                        Unit
+                    }
                     blobFullFile(
                         itemId = id,
                         filesDir = filePathProvider.fullArticleDir,

--- a/app/src/main/java/com/nononsenseapps/feeder/model/RssLocalSync.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/RssLocalSync.kt
@@ -429,16 +429,6 @@ class RssLocalSync(
                         }
                         Unit
                     }
-                    blobFile(itemId = id, filesDir = filePathProvider.oldArticleDir).let { file ->
-                        try {
-                            if (file.isFile) {
-                                file.delete()
-                            }
-                        } catch (e: IOException) {
-                            Log.e(LOG_TAG, "Failed to delete $file", e)
-                        }
-                        Unit
-                    }
                     blobFullFile(
                         itemId = id,
                         filesDir = filePathProvider.fullArticleDir,

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/MainActivity.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/MainActivity.kt
@@ -14,6 +14,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import com.nononsenseapps.feeder.background.runOnceRssSync
 import com.nononsenseapps.feeder.background.runOnceSyncChainGetUpdates
+import com.nononsenseapps.feeder.background.schedulePeriodicOrphanedFilesCleanup
 import com.nononsenseapps.feeder.base.DIAwareComponentActivity
 import com.nononsenseapps.feeder.notifications.NotificationsWorker
 import com.nononsenseapps.feeder.ui.compose.navigation.AddFeedDestination
@@ -66,6 +67,9 @@ class MainActivity : DIAwareComponentActivity() {
         super.onCreate(savedInstanceState)
 
         mainActivityViewModel.ensurePeriodicSyncConfigured()
+
+        // Configure daily cleanup of orphaned article files
+        schedulePeriodicOrphanedFilesCleanup(di)
 
         enableEdgeToEdge()
 

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleViewModel.kt
@@ -11,6 +11,7 @@ import com.nononsenseapps.feeder.archmodel.LinkOpener
 import com.nononsenseapps.feeder.archmodel.OpenAISettings
 import com.nononsenseapps.feeder.archmodel.Repository
 import com.nononsenseapps.feeder.archmodel.TextToDisplay
+import com.nononsenseapps.feeder.background.runOnceRssSync
 import com.nononsenseapps.feeder.base.DIAwareViewModel
 import com.nononsenseapps.feeder.blob.blobFile
 import com.nononsenseapps.feeder.blob.blobFullFile
@@ -204,7 +205,16 @@ class ArticleViewModel(
                                 LinearArticle(elements = emptyList())
                             }
                         } else {
-                            Log.e(LOG_TAG, "No default file to parse")
+                            // TODO use oldArticleDir as fallback
+                            Log.e(LOG_TAG, "No default file to parse. Attempting to fetch feed again")
+                            // Should not happen after moving articles to filesDir instead of cacheDir
+                            // but this is needed as the migration step
+                            runOnceRssSync(
+                                di = di,
+                                feedId = article.feedId,
+                                forceNetwork = true,
+                                triggeredByUser = true,
+                            )
                             textToDisplay.update { TextToDisplay.CONTENT }
                             htmlLinearizer.linearize(
                                 "Sorry, due to a coding oversight, " +

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleViewModel.kt
@@ -204,8 +204,24 @@ class ArticleViewModel(
                                 textToDisplay.update { TextToDisplay.FAILED_TO_LOAD_FULLTEXT }
                                 LinearArticle(elements = emptyList())
                             }
+                        } else if (blobFile(article.id, filePathProvider.oldArticleDir).isFile) {
+                            try {
+                                blobInputStream(article.id, filePathProvider.oldArticleDir)
+                                    .use {
+                                        htmlLinearizer.linearize(
+                                            inputStream = it,
+                                            baseUrl = article.feedUrl ?: "",
+                                        )
+                                    }.also {
+                                        textToDisplay.update { TextToDisplay.CONTENT }
+                                    }
+                            } catch (e: Exception) {
+                                // EOFException is possible
+                                Log.e(LOG_TAG, "Could not open blob", e)
+                                textToDisplay.update { TextToDisplay.FAILED_TO_LOAD_FULLTEXT }
+                                LinearArticle(elements = emptyList())
+                            }
                         } else {
-                            // TODO use oldArticleDir as fallback
                             Log.e(LOG_TAG, "No default file to parse. Attempting to fetch feed again")
                             // Should not happen after moving articles to filesDir instead of cacheDir
                             // but this is needed as the migration step

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleViewModel.kt
@@ -204,27 +204,9 @@ class ArticleViewModel(
                                 textToDisplay.update { TextToDisplay.FAILED_TO_LOAD_FULLTEXT }
                                 LinearArticle(elements = emptyList())
                             }
-                        } else if (blobFile(article.id, filePathProvider.oldArticleDir).isFile) {
-                            try {
-                                blobInputStream(article.id, filePathProvider.oldArticleDir)
-                                    .use {
-                                        htmlLinearizer.linearize(
-                                            inputStream = it,
-                                            baseUrl = article.feedUrl ?: "",
-                                        )
-                                    }.also {
-                                        textToDisplay.update { TextToDisplay.CONTENT }
-                                    }
-                            } catch (e: Exception) {
-                                // EOFException is possible
-                                Log.e(LOG_TAG, "Could not open blob", e)
-                                textToDisplay.update { TextToDisplay.FAILED_TO_LOAD_FULLTEXT }
-                                LinearArticle(elements = emptyList())
-                            }
                         } else {
                             Log.e(LOG_TAG, "No default file to parse. Attempting to fetch feed again")
-                            // Should not happen after moving articles to filesDir instead of cacheDir
-                            // but this is needed as the migration step
+                            // Should not happen but keeping this as a fallback
                             runOnceRssSync(
                                 di = di,
                                 feedId = article.feedId,

--- a/app/src/main/java/com/nononsenseapps/feeder/util/FilePathProvider.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/util/FilePathProvider.kt
@@ -15,6 +15,11 @@ interface FilePathProvider {
     val articleDir: File
 
     /**
+     * This is where articles regular text used to be placed. Kept for backwards compatibility.
+     */
+    val oldArticleDir: File
+
+    /**
      * This is where the full text of articles should be placed
      */
     val fullArticleDir: File
@@ -44,7 +49,8 @@ private class FilePathProviderImpl(
     override val cacheDir: File,
     override val filesDir: File,
 ) : FilePathProvider {
-    override val articleDir: File = cacheDir.resolve("articles")
+    override val articleDir: File = filesDir.resolve("articles")
+    override val oldArticleDir: File = cacheDir.resolve("articles")
     override val fullArticleDir: File = cacheDir.resolve("full_articles")
     override val httpCacheDir: File = cacheDir.resolve("http")
     override val imageCacheDir: File = cacheDir.resolve("image_cache")

--- a/app/src/main/java/com/nononsenseapps/feeder/util/FilePathProvider.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/util/FilePathProvider.kt
@@ -15,11 +15,6 @@ interface FilePathProvider {
     val articleDir: File
 
     /**
-     * This is where articles regular text used to be placed. Kept for backwards compatibility.
-     */
-    val oldArticleDir: File
-
-    /**
      * This is where the full text of articles should be placed
      */
     val fullArticleDir: File
@@ -50,7 +45,6 @@ private class FilePathProviderImpl(
     override val filesDir: File,
 ) : FilePathProvider {
     override val articleDir: File = filesDir.resolve("articles")
-    override val oldArticleDir: File = cacheDir.resolve("articles")
     override val fullArticleDir: File = cacheDir.resolve("full_articles")
     override val httpCacheDir: File = cacheDir.resolve("http")
     override val imageCacheDir: File = cacheDir.resolve("image_cache")


### PR DESCRIPTION
* Also adds a clean up job to delete orphaned files which was possible if you deleted feeds
* And on the off-chance that you open an article which doesn't exist on disk, Feeder will immediately trigger a new sync of the feed to try and get it

fixes: #443 