### PR TITLE
fix: fixed drawer not showing anymore when tapping on fab

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/FeedViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/FeedViewModel.kt
@@ -306,7 +306,7 @@ class FeedViewModel(
                 showOnlyTitle = params[23] as Boolean,
                 showReadingTime = params[24] as Boolean,
                 showTitleUnreadCount = params[25] as Boolean,
-                isOpenDrawerOnFab = params[26] as Boolean,
+                isOpenDrawerOnFab = params[27] as Boolean,
             )
         }.stateIn(
             viewModelScope,


### PR DESCRIPTION
I tried to take a look about issue #662 because it's super annoying after it has been working that it's not anymore.

Between 2.10.0 (not working) and 2.9.2 (working) only one commit has been made. (#647 feat: added a search function) I tried to look at what has been done and found that searchBarVisible and repository.search has been added as params 23 and 24 offsetting other ones by 2. 

Later on isOpenDrawerOnFab is set incorrectly with param 26 instead of 27. My PR correct it but I don't know if there is other changes to do. Please be indulgent with my PR and let me know if it's not ok how I should have done it. I am not a real developer, don't know kotlin / java and I have no environment for it. I edited directly the file on github and didn't have a build to test the fix. :-/

Fix #662