### PR TITLE
feat: removed Nostr support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Then build and install the app to your phone which is connected via USB:
 * Notification support
 * OPML import/export
 * Material Design
-* Nostr feeds
 
 ### Screenshots
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -248,9 +248,6 @@ dependencies {
     implementation(libs.openai.client)
     implementation(libs.ktor.client.okhttp)
 
-    // Nostr
-    implementation(libs.rust.nostr)
-
     // Markdown
     implementation(libs.jetbrains.markdown)
 

--- a/app/src/main/java/com/nononsenseapps/feeder/model/opml/OpmlPullParser.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/opml/OpmlPullParser.kt
@@ -6,8 +6,6 @@ import com.nononsenseapps.feeder.db.room.Feed
 import com.nononsenseapps.feeder.model.OPMLParserHandler
 import com.nononsenseapps.feeder.util.Either
 import com.nononsenseapps.feeder.util.flatMap
-import com.nononsenseapps.feeder.util.getOrCreateFromUri
-import com.nononsenseapps.feeder.util.isNostrUri
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.withContext
 import okio.ByteString.Companion.toByteString
@@ -255,7 +253,7 @@ class OpmlPullParser(
             )
         try {
             val parsedUrlOrUri = parser.getAttributeValue(null, ATTR_XMLURL)
-            val feedUrl = URL(parsedUrlOrUri.getOrCreateFromUri())
+            val feedUrl = URL(parsedUrlOrUri)
             val feed =
                 Feed(
                     // Ensure not both are empty string: title will get replaced on sync
@@ -272,21 +270,17 @@ class OpmlPullParser(
                                 ?.toBoolean()
                                 ?: feed.notify,
                         fullTextByDefault =
-                            if (parsedUrlOrUri.isNostrUri()) {
-                                false
-                            } else {
-                                (
-                                    parser
-                                        .getAttributeValue(
-                                            OPML_FEEDER_NAMESPACE,
-                                            ATTR_FULL_TEXT_BY_DEFAULT,
-                                        )?.toBoolean()
-                                        // Support Flym's value for this
-                                        ?: parser
-                                            .getAttributeValue(null, ATTR_FLYM_RETRIEVE_FULL_TEXT)
-                                            ?.toBoolean()
-                                ) ?: feed.fullTextByDefault
-                            },
+                            (
+                                parser
+                                    .getAttributeValue(
+                                        OPML_FEEDER_NAMESPACE,
+                                        ATTR_FULL_TEXT_BY_DEFAULT,
+                                    )?.toBoolean()
+                                    // Support Flym's value for this
+                                    ?: parser
+                                        .getAttributeValue(null, ATTR_FLYM_RETRIEVE_FULL_TEXT)
+                                        ?.toBoolean()
+                            ) ?: feed.fullTextByDefault,
                         alternateId =
                             parser
                                 .getAttributeValue(OPML_FEEDER_NAMESPACE, ATTR_ALTERNATE_ID)

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/Constants.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/Constants.kt
@@ -14,5 +14,3 @@ const val ARG_FEED_FULL_TEXT_BY_DEFAULT = "feed_full_text_by_default"
 const val ARG_FEED_OPEN_ARTICLES_WITH = "feed_open_articles_with"
 const val ARG_URL = "url"
 const val ARG_ONLY_NEW = "only_new"
-
-const val NOSTR_URI_PREFIX = "nostr:"

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/editfeed/CreateFeedScreenViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/editfeed/CreateFeedScreenViewModel.kt
@@ -14,8 +14,6 @@ import com.nononsenseapps.feeder.background.runOnceRssSync
 import com.nononsenseapps.feeder.base.DIAwareViewModel
 import com.nononsenseapps.feeder.db.room.Feed
 import com.nononsenseapps.feeder.ui.compose.utils.mutableSavedStateOf
-import com.nononsenseapps.feeder.util.getOrCreateFromUri
-import com.nononsenseapps.feeder.util.isNostrUri
 import com.nononsenseapps.feeder.util.sloppyLinkToStrictURLOrNull
 import kotlinx.coroutines.launch
 import org.kodein.di.DI
@@ -84,11 +82,11 @@ class CreateFeedScreenViewModel(
             val feedId =
                 repository.saveFeed(
                     Feed(
-                        url = URL(feedUrl.getOrCreateFromUri()),
+                        url = URL(feedUrl),
                         title = feedTitle,
                         customTitle = feedTitle,
                         tag = feedTag,
-                        fullTextByDefault = if (feedUrl.isNostrUri()) false else fullTextByDefault,
+                        fullTextByDefault = fullTextByDefault,
                         notify = notify,
                         skipDuplicates = skipDuplicates,
                         openArticlesWith = articleOpener,

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/editfeed/EditFeedScreen.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/editfeed/EditFeedScreen.kt
@@ -83,7 +83,6 @@ import com.nononsenseapps.feeder.ui.compose.utils.LocalWindowSizeMetrics
 import com.nononsenseapps.feeder.ui.compose.utils.ScreenType
 import com.nononsenseapps.feeder.ui.compose.utils.getScreenType
 import com.nononsenseapps.feeder.ui.compose.utils.rememberApiPermissionState
-import com.nononsenseapps.feeder.util.isNostrUri
 
 @Composable
 fun CreateFeedScreen(
@@ -495,7 +494,6 @@ fun ColumnScope.RightContent(
                     previous = leftFocusRequester
                 },
         icon = null,
-        enabled = !viewState.feedUrl.isNostrUri(),
     )
     SwitchSetting(
         title = stringResource(id = R.string.notify_for_new_items),

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/editfeed/EditFeedScreenViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/editfeed/EditFeedScreenViewModel.kt
@@ -14,8 +14,6 @@ import com.nononsenseapps.feeder.background.runOnceRssSync
 import com.nononsenseapps.feeder.base.DIAwareViewModel
 import com.nononsenseapps.feeder.db.room.Feed
 import com.nononsenseapps.feeder.ui.compose.utils.mutableSavedStateOf
-import com.nononsenseapps.feeder.util.getOrCreateFromUri
-import com.nononsenseapps.feeder.util.isNostrUri
 import kotlinx.coroutines.launch
 import org.kodein.di.DI
 import org.kodein.di.instance
@@ -126,11 +124,11 @@ class EditFeedScreenViewModel(
 
             val updatedFeed =
                 feed.copy(
-                    url = URL(feedUrl.getOrCreateFromUri()),
+                    url = URL(feedUrl),
                     title = feedTitle,
                     customTitle = feedTitle,
                     tag = feedTag,
-                    fullTextByDefault = if (feedUrl.isNostrUri()) false else fullTextByDefault,
+                    fullTextByDefault = fullTextByDefault,
                     notify = notify,
                     skipDuplicates = skipDuplicates,
                     openArticlesWith = articleOpener,
@@ -158,12 +156,8 @@ class EditFeedScreenViewModel(
 
 internal fun isValidUrlOrUri(value: String): Boolean =
     try {
-        if (value.isNostrUri()) {
-            true
-        } else {
-            URL(value)
-            true
-        }
-    } catch (e: Exception) {
+        URL(value)
+        true
+    } catch (_: Exception) {
         false
     }

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/searchfeed/SearchFeedViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/searchfeed/SearchFeedViewModel.kt
@@ -4,19 +4,16 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.nononsenseapps.feeder.FeederApplication
-import com.nononsenseapps.feeder.R
 import com.nononsenseapps.feeder.archmodel.Repository
 import com.nononsenseapps.feeder.base.DIAwareViewModel
 import com.nononsenseapps.feeder.model.FeedParser
 import com.nononsenseapps.feeder.model.FeedParserError
-import com.nononsenseapps.feeder.model.FetchError
 import com.nononsenseapps.feeder.model.HttpError
 import com.nononsenseapps.feeder.model.NoAlternateFeeds
 import com.nononsenseapps.feeder.model.NotInitializedYet
 import com.nononsenseapps.feeder.model.SiteMetaData
 import com.nononsenseapps.feeder.util.Either
 import com.nononsenseapps.feeder.util.flatMap
-import com.nononsenseapps.feeder.util.isAdaptedUrlFromNostrUri
 import com.nononsenseapps.feeder.util.sloppyLinkToStrictURLOrNull
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -42,77 +39,51 @@ class SearchFeedViewModel(
     )
 
     fun searchForFeeds(initialUrl: URL): Flow<Either<FeedParserError, SearchResult>> =
-        if (initialUrl.isAdaptedUrlFromNostrUri()) {
-            flow {
-                val nostrProfile = feedParser.getProfileMetadata(initialUrl)
-                nostrProfile
-                    .onRight {
-                        emit(Either.Right(it))
-                    }.onLeft {
-                        emit(Either.Left(it))
-                    }
-            }.map { profileResult ->
-                profileResult.flatMap { metadata ->
+        flow {
+            siteMetaData = feedParser.getSiteMetaData(initialUrl)
+            // Flow collection makes this block concurrent with map below
+            val initialSiteMetaData = siteMetaData
 
-                    Either.catching(
-                        onCatch = { t -> FetchError(url = metadata.uri, throwable = t) },
-                    ) {
-                        SearchResult(
-                            title = metadata.name,
-                            url = metadata.uri,
-                            description = application.applicationContext.getString(R.string.nostr_feed_description, metadata.name),
-                            feedImage = metadata.imageUrl,
-                        )
+            initialSiteMetaData
+                .onRight { metaData ->
+                    metaData.alternateFeedLinks.forEach {
+                        emit(Either.Right(it.link))
                     }
+                    if (metaData.alternateFeedLinks.isEmpty()) {
+                        emit(Either.Left(NoAlternateFeeds(initialUrl.toString())))
+                    }
+                }.onLeft {
+                    if (it is HttpError) {
+                        handleHttpError(it)
+                    }
+                    emit(Either.Right(initialUrl))
                 }
-            }.flowOn(Dispatchers.Default)
-        } else {
-            flow {
-                siteMetaData = feedParser.getSiteMetaData(initialUrl)
-                // Flow collection makes this block concurrent with map below
-                val initialSiteMetaData = siteMetaData
-
-                initialSiteMetaData
-                    .onRight { metaData ->
-                        metaData.alternateFeedLinks.forEach {
-                            emit(Either.Right(it.link))
+        }.map { urlResult ->
+            urlResult.flatMap { url ->
+                feedParser
+                    .parseFeedUrl(url)
+                    .onRight { feed ->
+                        if (siteMetaData.isLeft()) {
+                            feed.home_page_url?.let { pageLink ->
+                                sloppyLinkToStrictURLOrNull(pageLink)?.let { pageUrl ->
+                                    siteMetaData = feedParser.getSiteMetaData(pageUrl)
+                                }
+                            }
                         }
-                        if (metaData.alternateFeedLinks.isEmpty()) {
-                            emit(Either.Left(NoAlternateFeeds(initialUrl.toString())))
-                        }
+                    }.map { feed ->
+                        SearchResult(
+                            title = feed.title ?: "",
+                            url = feed.feed_url ?: url.toString(),
+                            description = feed.description ?: "",
+                            feedImage = siteMetaData.getOrNull()?.feedImage ?: "",
+                        )
                     }.onLeft {
                         if (it is HttpError) {
                             handleHttpError(it)
                         }
-                        emit(Either.Right(initialUrl))
                     }
-            }.map { urlResult ->
-                urlResult.flatMap { url ->
-                    feedParser
-                        .parseFeedUrl(url)
-                        .onRight { feed ->
-                            if (siteMetaData.isLeft()) {
-                                feed.home_page_url?.let { pageLink ->
-                                    sloppyLinkToStrictURLOrNull(pageLink)?.let { pageUrl ->
-                                        siteMetaData = feedParser.getSiteMetaData(pageUrl)
-                                    }
-                                }
-                            }
-                        }.map { feed ->
-                            SearchResult(
-                                title = feed.title ?: "",
-                                url = feed.feed_url ?: url.toString(),
-                                description = feed.description ?: "",
-                                feedImage = siteMetaData.getOrNull()?.feedImage ?: "",
-                            )
-                        }.onLeft {
-                            if (it is HttpError) {
-                                handleHttpError(it)
-                            }
-                        }
-                }
-            }.flowOn(Dispatchers.Default)
-        }
+            }
+        }.flowOn(Dispatchers.Default)
 
     private suspend fun handleHttpError(httpError: HttpError) {
         httpError.retryAfterSeconds?.let { retryAfterSeconds ->

--- a/app/src/main/java/com/nononsenseapps/feeder/util/LinkUtils.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/util/LinkUtils.kt
@@ -1,6 +1,5 @@
 package com.nononsenseapps.feeder.util
 
-import com.nononsenseapps.feeder.ui.NOSTR_URI_PREFIX
 import java.net.MalformedURLException
 import java.net.URI
 import java.net.URISyntaxException
@@ -99,9 +98,3 @@ fun relativeLinkIntoAbsoluteOrThrow(
     } catch (_: MalformedURLException) {
         URL(base, link)
     }
-
-fun String.isNostrUri(): Boolean = startsWith(NOSTR_URI_PREFIX) && length > NOSTR_URI_PREFIX.length
-
-fun URL.isAdaptedUrlFromNostrUri(): Boolean = this.toString().startsWith("https://njump.me")
-
-fun String.getOrCreateFromUri(): String = if (isNostrUri()) "https://njump.me/$this" else this

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,7 +42,6 @@ androidWindow = "1.4.0"
 lazycolumnscrollbar = "2.2.0"
 androidxBrowser = "1.8.0"
 jetbrains-markdown = "0.7.3"
-rust-nostr = "0.39.0"
 junit = "4.13.2"
 espresso = "3.6.1"
 mockk = "1.14.2"
@@ -90,7 +89,6 @@ jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 tagsoup = { module = "org.ccil.cowan.tagsoup:tagsoup", version.ref = "tagsoup" }
 icu4j = { module = "com.ibm.icu:icu4j", version.ref = "icu4j" }
 gofeed-android = { module = "com.nononsenseapps.gofeed:gofeed-android", version.ref = "gofeed" }
-rust-nostr = { module = "org.rust-nostr:nostr-sdk", version.ref = "rust-nostr" }
 jetbrains-markdown = { module = "org.jetbrains:markdown", version.ref = "jetbrains-markdown" }
 okhttp = { module = "com.squareup.okhttp3:okhttp" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }


### PR DESCRIPTION
Removing Nostr support because the API is not yet stable enough. Upgrading from `0.39` to `0.42` required fixing breaking changes that would entail re-organizing the code in Feeder to accomodate the changed code, and it was very non-obvious how to do that without researching how Nostr works in more detail.  I don't have the time to invest in supporting something that I am not a user of.

I want to be clear that this is not any critique of Nostr or the client library. It is still in active development. 

Nostr support is welcome back once a more stable client library exists (e.g. version `1.x.x`).