### PR TITLE
feat: removed Conscrypt library

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/FeederApplication.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/FeederApplication.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import android.app.job.JobScheduler
 import android.content.ContentResolver
 import android.content.SharedPreferences
-import android.util.Log
 import android.widget.Toast
 import androidx.core.app.NotificationManagerCompat
 import androidx.preference.PreferenceManager
@@ -53,7 +52,6 @@ import okhttp3.Cache
 import okhttp3.CacheControl
 import okhttp3.OkHttpClient
 import okio.Path.Companion.toOkioPath
-import org.conscrypt.Conscrypt
 import org.kodein.di.DI
 import org.kodein.di.DIAware
 import org.kodein.di.bind
@@ -61,7 +59,6 @@ import org.kodein.di.direct
 import org.kodein.di.instance
 import org.kodein.di.singleton
 import java.io.File
-import java.security.Security
 import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalCoilApi::class)
@@ -210,17 +207,6 @@ class FeederApplication :
         import(networkModule)
         bind<TTSStateHolder>() with instance(ttsStateHolder)
         bind<NotificationsWorker>() with singleton { NotificationsWorker(di) }
-    }
-
-    init {
-        // Install Conscrypt to handle TLSv1.3 pre Android10
-        // This crashes if app is installed to SD-card. Since it should still work for many
-        // devices, try to ignore errors
-        try {
-            Security.insertProviderAt(Conscrypt.newProvider(), 1)
-        } catch (t: Throwable) {
-            Log.e(LOG_TAG, "Failed to insert Conscrypt. Attempt to ignore.", t)
-        }
     }
 
     override fun onCreate() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,8 +8,6 @@ androidPlugin = "8.10.1"
 # BEGIN These should be upgraded in unison. See https://square.github.io/okhttp/changelogs/changelog_4x/
 okhttp = "4.12.0"
 okio = "3.6.0"
-# 2.5.3 and above are 16kb aligned
-conscrypt = "2.5.3"
 # END Unison
 ktlint-gradle = "12.3.0"
 ktlint-compose = "0.4.22"
@@ -93,7 +91,6 @@ gofeed-android = { module = "com.nononsenseapps.gofeed:gofeed-android", version.
 jetbrains-markdown = { module = "org.jetbrains:markdown", version.ref = "jetbrains-markdown" }
 okhttp = { module = "com.squareup.okhttp3:okhttp" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
-conscrypt-android = { module = "org.conscrypt:conscrypt-android", version.ref = "conscrypt" }
 coil-gif = { module = "io.coil-kt.coil3:coil-gif", version.ref = "coil" }
 coil-svg = { module = "io.coil-kt.coil3:coil-svg", version.ref = "coil" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
@@ -141,7 +138,7 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 ktlint-gradle = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-gradle" }
 
 [bundles]
-okhttp-android = ["okhttp", "okio", "conscrypt-android"]
+okhttp-android = ["okhttp", "okio"]
 kotlin = ["kotlin-stdlib", "kotlin-stdlib-common", "kotlin-coroutines-core", "kotlin-serialization-json"]
 jvm = ["jsoup", "tagsoup", "readability4j", "retrofit", "retrofit-converter-moshi", "moshi", "moshi-kotlin", "moshi-adapters", "qrgen", "gofeed-android", "icu4j"]
 android = ["lifecycle-runtime-ktx", "lifecycle-viewmodel-ktx", "lifecycle-viewmodel-savedstate", "paging-runtime-ktx", "room-ktx", "room-paging", "core-ktx", "androidx-appcompat", "androidx-preference", "coil-gif", "coil-svg", "coil-okhttp", "kotlin-coroutines-android", "kodein-androidx", "androidx-browser", "emoji2", "emoji2-view-helper"]


### PR DESCRIPTION
Older devices may have trouble connecting to sites if they are using TLSv3. But this library is a source of so many crashes it just isn't worth keeping.

Fixes #788 