### PR TITLE
feat: Android 10 (sdk29) is now the oldest supported version

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,10 +34,11 @@ android {
     defaultConfig {
         applicationId = "com.nononsenseapps.feeder"
         // The version fields are set with actual values to support F-Droid
-        // In Play variant, they are overriden and taken from git.
+        // In Play variant, they are overridden and taken from git.
         versionCode = 3691
         versionName = "2.11.5"
-        minSdk = 23
+        // TLS1.3 is enabled in Android 10 (29) and above
+        minSdk = 29
         targetSdk = 35
 
         vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
Removing Conscrypt means relying on platform HTTPS support and TLS1.3 was enabled in SDK29 (Android 10). Hence bumping to that.

This was released in 2019. So in effect supporting devices which received their last OS update 6 years ago.

In Google play, June 2nd 2025, 1.82% of users are on a version of Android older than 10.