### PR TITLE
fix: increased allowed cache sizes

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/FeederApplication.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/FeederApplication.kt
@@ -13,6 +13,7 @@ import coil3.SingletonImageLoader
 import coil3.annotation.ExperimentalCoilApi
 import coil3.disk.DiskCache
 import coil3.memory.MemoryCache
+import coil3.memoryCacheMaxSizePercentWhileInBackground
 import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import coil3.request.crossfade
 import coil3.request.maxBitmapSize
@@ -180,6 +181,7 @@ class FeederApplication :
                     .crossfade(true)
                     .coroutineContext(applicationCoroutineScope.coroutineContext)
                     .maxBitmapSize(Size(2500, 2500))
+                    .memoryCacheMaxSizePercentWhileInBackground(0.05)
                     .diskCache(
                         DiskCache
                             .Builder()


### PR DESCRIPTION
Increased HTTP response disk cache to 200MB (from 50MB)

Increased HTTP Image response disk cache to 300MB (from 25MB)

Decreased Coil Image disk cache to 200MB (from 250MB)

Increased Coil Image memory cache to 100MB (from 50MB), but it will prune itself to 5MB when app is backgrounded