### PR TITLE
feat: moved bug report button to settings

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
@@ -40,7 +40,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.CheckBox
 import androidx.compose.material.icons.filled.CheckBoxOutlineBlank
 import androidx.compose.material.icons.filled.Close
@@ -151,7 +150,6 @@ import com.nononsenseapps.feeder.ui.compose.utils.onKeyEventLikeEscape
 import com.nononsenseapps.feeder.util.ActivityLauncher
 import com.nononsenseapps.feeder.util.ToastMaker
 import com.nononsenseapps.feeder.util.logDebug
-import com.nononsenseapps.feeder.util.openGithubIssues
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.kodein.di.compose.LocalDI
@@ -320,12 +318,6 @@ fun FeedScreen(
             onSettings = {
                 SettingsDestination.navigate(navController)
             },
-            onSendFeedback = {
-                activityLauncher.startActivity(
-                    openAdjacentIfSuitable = true,
-                    intent = openGithubIssues(),
-                )
-            },
             onImport = {
                 try {
                     opmlImporter.launch(
@@ -451,7 +443,6 @@ fun FeedScreen(
     onShowDeleteDialog: () -> Unit,
     onDismissDeleteDialog: () -> Unit,
     onSettings: () -> Unit,
-    onSendFeedback: () -> Unit,
     onImport: () -> Unit,
     onExportOPML: () -> Unit,
     onExportSavedArticles: () -> Unit,
@@ -867,22 +858,6 @@ fun FeedScreen(
                                 },
                                 text = {
                                     Text(stringResource(id = R.string.action_settings))
-                                },
-                            )
-                            HorizontalDivider()
-                            DropdownMenuItem(
-                                onClick = {
-                                    onShowToolbarMenu(false)
-                                    onSendFeedback()
-                                },
-                                leadingIcon = {
-                                    Icon(
-                                        Icons.Default.BugReport,
-                                        contentDescription = null,
-                                    )
-                                },
-                                text = {
-                                    Text(stringResource(id = R.string.send_bug_report))
                                 },
                             )
                             // Hidden button for TalkBack


### PR DESCRIPTION
This PR is intended to address issue #772. 

**Task:**
Move the Submit bug report button from the overflow menu in the Feed Screen's Top Bar to the Settings screen, as this is a more logical place for this action to exist.

**Solution:**
Removed the code for the menu item in FeedScreen.kt, any handling code, and trailing imports. 
Created a new `ActionSetting` composable for the Bug Report button
- this is essentially an `ExternalSetting`, only without the `currentValue` passed as the subtitle. It might make more sense to just modify this Composable to accept an optional param for the currentValue
Cleaned up warnings in the affected files

**Testing:**
I ran this manually on an emulator to confirm behavior. Screenshots display the new location of the bug report button.
<img width="270" height="600" alt="Screenshot_20250818_235250" src="https://github.com/user-attachments/assets/b925738c-84e0-4a50-a5fe-dfacf42ad56b" /> <img width="270" height="600" alt="Screenshot_20250818_235350" src="https://github.com/user-attachments/assets/e06e0755-92f0-4d37-8a06-4529cfc5e990" /> 
[Screen_recording_20250818_235415.webm](https://github.com/user-attachments/assets/011fc656-f93f-4582-a4ad-2defcec10fdd)

