### PR TITLE
fix: localized numbers in the drawer

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/navdrawer/NavDrawer.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/navdrawer/NavDrawer.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
@@ -69,7 +70,6 @@ import com.nononsenseapps.feeder.ui.compose.material3.DrawerState
 import com.nononsenseapps.feeder.ui.compose.utils.onKeyEventLikeEscape
 import com.nononsenseapps.feeder.util.logDebug
 import kotlinx.coroutines.launch
-import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalAnimationApi::class)
 @Composable
@@ -319,7 +319,7 @@ private fun ExpandableTag(
                     unreadCount,
                 )
             Text(
-                text = "%d".format(Locale.getDefault(), unreadCount),
+                text = "%d".format(LocalConfiguration.current.locales[0], unreadCount),
                 maxLines = 1,
                 modifier =
                     Modifier
@@ -452,7 +452,7 @@ private fun AllFeeds(
                     unreadCount,
                 )
             Text(
-                text = "%d".format(Locale.getDefault(), unreadCount),
+                text = "%d".format(LocalConfiguration.current.locales[0], unreadCount),
                 maxLines = 1,
                 modifier =
                     Modifier.semantics {
@@ -518,7 +518,7 @@ private fun Feed(
                     unreadCount,
                 )
             Text(
-                text = "%d".format(Locale.getDefault(), unreadCount),
+                text = "%d".format(LocalConfiguration.current.locales[0], unreadCount),
                 maxLines = 1,
                 modifier =
                     Modifier.semantics {


### PR DESCRIPTION
This is a localization change similar to this change https://github.com/AntennaPod/AntennaPod/pull/4032 which won't have any effect in English but improves the other language that have their own digits.

Before:
<img width="311" height="247" alt="image" src="https://github.com/user-attachments/assets/1dae0a0a-e97b-4b00-b85f-4add0ef98ae0" />

After:
<img width="319" height="281" alt="image" src="https://github.com/user-attachments/assets/5f58fbe1-77e5-4c8a-b8a5-97cd30bad79d" />

