### PR TITLE
feat: improved swipe to dismiss experience

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedItemCompact.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedItemCompact.kt
@@ -62,13 +62,10 @@ fun FeedItemCompact(
     modifier: Modifier = Modifier,
     imageWidth: Dp = 64.dp,
 ) {
-    Surface {
+    Surface(modifier = modifier.height(IntrinsicSize.Min)) {
         Row(
             horizontalArrangement = Arrangement.spacedBy(4.dp),
-            modifier =
-                modifier
-                    .height(IntrinsicSize.Min)
-                    .padding(start = LocalDimens.current.margin),
+            modifier = Modifier.padding(start = LocalDimens.current.margin),
         ) {
             FeedItemText(
                 item = item,

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedItemCompact.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedItemCompact.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
@@ -62,88 +62,90 @@ fun FeedItemCompact(
     modifier: Modifier = Modifier,
     imageWidth: Dp = 64.dp,
 ) {
-    Row(
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-        modifier =
-            modifier
-                .height(IntrinsicSize.Min)
-                .padding(start = LocalDimens.current.margin),
-    ) {
-        FeedItemText(
-            item = item,
-            onMarkAboveAsRead = onMarkAboveAsRead,
-            onMarkBelowAsRead = onMarkBelowAsRead,
-            onShareItem = onShareItem,
-            onToggleBookmark = onToggleBookmark,
-            dropDownMenuExpanded = dropDownMenuExpanded,
-            onDismissDropdown = onDismissDropdown,
-            maxLines = maxLines,
-            showOnlyTitle = showOnlyTitle,
-            showReadingTime = showReadingTime,
+    Surface {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
             modifier =
-                Modifier
-                    .requiredHeightIn(min = minimumTouchSize)
-                    .padding(vertical = 8.dp),
-        )
+                modifier
+                    .height(IntrinsicSize.Min)
+                    .padding(start = LocalDimens.current.margin),
+        ) {
+            FeedItemText(
+                item = item,
+                onMarkAboveAsRead = onMarkAboveAsRead,
+                onMarkBelowAsRead = onMarkBelowAsRead,
+                onShareItem = onShareItem,
+                onToggleBookmark = onToggleBookmark,
+                dropDownMenuExpanded = dropDownMenuExpanded,
+                onDismissDropdown = onDismissDropdown,
+                maxLines = maxLines,
+                showOnlyTitle = showOnlyTitle,
+                showReadingTime = showReadingTime,
+                modifier =
+                    Modifier
+                        .requiredHeightIn(min = minimumTouchSize)
+                        .padding(vertical = 8.dp),
+            )
 
-        if ((item.bookmarked && bookmarkIndicator) || showThumbnail && (item.image != null || item.feedImageUrl != null)) {
-            Box(
-                modifier = Modifier.fillMaxHeight(),
-                contentAlignment = Alignment.TopEnd,
-            ) {
-                if (item.bookmarked && bookmarkIndicator) {
-                    FeedItemEitherIndicator(
-                        bookmarked = true,
-                        itemImage = null,
-                        feedImageUrl = null,
-                        size = 24.dp,
-                        modifier =
-                            Modifier
-                                .fillMaxHeight()
-                                .width(64.dp),
-                    )
-                } else {
-                    (item.image?.url ?: item.feedImageUrl?.toString())?.let { imageUrl ->
-                        val pixelDensity = LocalDensity.current.density
-                        val scale =
-                            if (item.image != null) {
-                                RestrainedCropScaling(pixelDensity)
-                            } else {
-                                RestrainedFitScaling(pixelDensity)
-                            }
-                        val pixels =
-                            with(LocalDensity.current) {
-                                val px = imageWidth.toPx()
-                                Size(px.roundToInt(), (px * 1.5).roundToInt())
-                            }
-                        AsyncImage(
-                            model =
-                                ImageRequest
-                                    .Builder(LocalContext.current)
-                                    .data(imageUrl)
-                                    .listener(
-                                        onError = { a, b ->
-                                            logDebug("FEEDER_COMPACT", "error ${a.data}", b.throwable)
-                                        },
-                                    ).scale(Scale.FILL)
-                                    .size(pixels)
-                                    .precision(Precision.INEXACT)
-                                    .build(),
-                            placeholder = rememberTintedVectorPainter(Icons.Outlined.Terrain),
-                            error = rememberTintedVectorPainter(Icons.Outlined.ErrorOutline),
-                            contentDescription = null,
-                            contentScale = scale,
+            if ((item.bookmarked && bookmarkIndicator) || showThumbnail && (item.image != null || item.feedImageUrl != null)) {
+                Box(
+                    modifier = Modifier.fillMaxHeight(),
+                    contentAlignment = Alignment.TopEnd,
+                ) {
+                    if (item.bookmarked && bookmarkIndicator) {
+                        FeedItemEitherIndicator(
+                            bookmarked = true,
+                            itemImage = null,
+                            feedImageUrl = null,
+                            size = 24.dp,
                             modifier =
                                 Modifier
-                                    .width(imageWidth)
-                                    .fillMaxHeight(),
+                                    .fillMaxHeight()
+                                    .width(64.dp),
                         )
+                    } else {
+                        (item.image?.url ?: item.feedImageUrl?.toString())?.let { imageUrl ->
+                            val pixelDensity = LocalDensity.current.density
+                            val scale =
+                                if (item.image != null) {
+                                    RestrainedCropScaling(pixelDensity)
+                                } else {
+                                    RestrainedFitScaling(pixelDensity)
+                                }
+                            val pixels =
+                                with(LocalDensity.current) {
+                                    val px = imageWidth.toPx()
+                                    Size(px.roundToInt(), (px * 1.5).roundToInt())
+                                }
+                            AsyncImage(
+                                model =
+                                    ImageRequest
+                                        .Builder(LocalContext.current)
+                                        .data(imageUrl)
+                                        .listener(
+                                            onError = { a, b ->
+                                                logDebug("FEEDER_COMPACT", "error ${a.data}", b.throwable)
+                                            },
+                                        ).scale(Scale.FILL)
+                                        .size(pixels)
+                                        .precision(Precision.INEXACT)
+                                        .build(),
+                                placeholder = rememberTintedVectorPainter(Icons.Outlined.Terrain),
+                                error = rememberTintedVectorPainter(Icons.Outlined.ErrorOutline),
+                                contentDescription = null,
+                                contentScale = scale,
+                                modifier =
+                                    Modifier
+                                        .width(imageWidth)
+                                        .fillMaxHeight(),
+                            )
+                        }
                     }
                 }
+            } else {
+                // Taking Row spacing into account
+                Spacer(modifier = Modifier.width(LocalDimens.current.margin - 4.dp))
             }
-        } else {
-            // Taking Row spacing into account
-            Spacer(modifier = Modifier.width(LocalDimens.current.margin - 4.dp))
         }
     }
 }
@@ -185,10 +187,88 @@ data class FeedListItem(
 }
 
 @Composable
-@Preview(showBackground = true)
+@PreviewLightDark
 private fun PreviewRead() {
     PreviewTheme {
-        Surface {
+        FeedItemCompact(
+            item =
+                @Suppress("ktlint:standard:max-line-length")
+                FeedListItem(
+                    title = "title",
+                    snippet = "snippet which is quite long as you might expect from a snipper of a story. It keeps going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and snowing",
+                    feedTitle = "Super Duper Feed One two three hup di too dasf",
+                    pubDate = "Jun 9, 2021",
+                    unread = false,
+                    image = null,
+                    link = null,
+                    id = ID_UNSET,
+                    bookmarked = false,
+                    feedImageUrl = null,
+                    primarySortTime = Instant.EPOCH,
+                    rawPubDate = null,
+                    wordCount = 900,
+                ),
+            showThumbnail = true,
+            onMarkAboveAsRead = {},
+            onMarkBelowAsRead = {},
+            onShareItem = {},
+            onToggleBookmark = {},
+            dropDownMenuExpanded = false,
+            onDismissDropdown = {},
+            bookmarkIndicator = true,
+            maxLines = 5,
+            showOnlyTitle = false,
+            showReadingTime = true,
+            imageWidth = 64.dp,
+        )
+    }
+}
+
+@Composable
+@PreviewLightDark
+private fun PreviewUnread() {
+    PreviewTheme {
+        FeedItemCompact(
+            item =
+                @Suppress("ktlint:standard:max-line-length")
+                FeedListItem(
+                    title = "title",
+                    snippet = "snippet which is quite long as you might expect from a snipper of a story. It keeps going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and snowing",
+                    feedTitle = "Super Duper Feed One two three hup di too dasf",
+                    pubDate = "Jun 9, 2021",
+                    unread = true,
+                    image = null,
+                    link = null,
+                    id = ID_UNSET,
+                    bookmarked = true,
+                    feedImageUrl = null,
+                    primarySortTime = Instant.EPOCH,
+                    rawPubDate = null,
+                    wordCount = 900,
+                ),
+            showThumbnail = true,
+            onMarkAboveAsRead = {},
+            onMarkBelowAsRead = {},
+            onShareItem = {},
+            onToggleBookmark = {},
+            dropDownMenuExpanded = false,
+            onDismissDropdown = {},
+            bookmarkIndicator = true,
+            maxLines = 5,
+            showOnlyTitle = false,
+            showReadingTime = true,
+            imageWidth = 64.dp,
+        )
+    }
+}
+
+@Composable
+@PreviewLightDark
+private fun PreviewWithImage() {
+    PreviewTheme {
+        Box(
+            modifier = Modifier.width(400.dp),
+        ) {
             FeedItemCompact(
                 item =
                     @Suppress("ktlint:standard:max-line-length")
@@ -197,8 +277,8 @@ private fun PreviewRead() {
                         snippet = "snippet which is quite long as you might expect from a snipper of a story. It keeps going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and snowing",
                         feedTitle = "Super Duper Feed One two three hup di too dasf",
                         pubDate = "Jun 9, 2021",
-                        unread = false,
-                        image = null,
+                        unread = true,
+                        image = MediaImage("blabla"),
                         link = null,
                         id = ID_UNSET,
                         bookmarked = false,
@@ -220,90 +300,6 @@ private fun PreviewRead() {
                 showReadingTime = true,
                 imageWidth = 64.dp,
             )
-        }
-    }
-}
-
-@Composable
-@Preview(showBackground = true)
-private fun PreviewUnread() {
-    PreviewTheme {
-        Surface {
-            FeedItemCompact(
-                item =
-                    @Suppress("ktlint:standard:max-line-length")
-                    FeedListItem(
-                        title = "title",
-                        snippet = "snippet which is quite long as you might expect from a snipper of a story. It keeps going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and snowing",
-                        feedTitle = "Super Duper Feed One two three hup di too dasf",
-                        pubDate = "Jun 9, 2021",
-                        unread = true,
-                        image = null,
-                        link = null,
-                        id = ID_UNSET,
-                        bookmarked = true,
-                        feedImageUrl = null,
-                        primarySortTime = Instant.EPOCH,
-                        rawPubDate = null,
-                        wordCount = 900,
-                    ),
-                showThumbnail = true,
-                onMarkAboveAsRead = {},
-                onMarkBelowAsRead = {},
-                onShareItem = {},
-                onToggleBookmark = {},
-                dropDownMenuExpanded = false,
-                onDismissDropdown = {},
-                bookmarkIndicator = true,
-                maxLines = 5,
-                showOnlyTitle = false,
-                showReadingTime = true,
-                imageWidth = 64.dp,
-            )
-        }
-    }
-}
-
-@Composable
-@Preview(showBackground = true)
-private fun PreviewWithImage() {
-    PreviewTheme {
-        Surface {
-            Box(
-                modifier = Modifier.width(400.dp),
-            ) {
-                FeedItemCompact(
-                    item =
-                        @Suppress("ktlint:standard:max-line-length")
-                        FeedListItem(
-                            title = "title",
-                            snippet = "snippet which is quite long as you might expect from a snipper of a story. It keeps going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and snowing",
-                            feedTitle = "Super Duper Feed One two three hup di too dasf",
-                            pubDate = "Jun 9, 2021",
-                            unread = true,
-                            image = MediaImage("blabla"),
-                            link = null,
-                            id = ID_UNSET,
-                            bookmarked = false,
-                            feedImageUrl = null,
-                            primarySortTime = Instant.EPOCH,
-                            rawPubDate = null,
-                            wordCount = 900,
-                        ),
-                    showThumbnail = true,
-                    onMarkAboveAsRead = {},
-                    onMarkBelowAsRead = {},
-                    onShareItem = {},
-                    onToggleBookmark = {},
-                    dropDownMenuExpanded = false,
-                    onDismissDropdown = {},
-                    bookmarkIndicator = true,
-                    maxLines = 5,
-                    showOnlyTitle = false,
-                    showReadingTime = true,
-                    imageWidth = 64.dp,
-                )
-            }
         }
     }
 }

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedItemSuperCompact.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedItemSuperCompact.kt
@@ -8,7 +8,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.nononsenseapps.feeder.db.room.ID_UNSET
 import com.nononsenseapps.feeder.model.MediaImage
@@ -33,145 +33,141 @@ fun FeedItemSuperCompact(
     showReadingTime: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        modifier =
-            modifier
-                .requiredHeightIn(min = minimumTouchSize)
-                .padding(vertical = 8.dp, horizontal = LocalDimens.current.margin),
-    ) {
-        FeedItemEitherIndicator(
-            bookmarked = item.bookmarked && bookmarkIndicator,
-            itemImage = null,
-            feedImageUrl = item.feedImageUrl?.toString(),
-            size = 24.dp,
-        )
-        FeedItemText(
-            item = item,
-            onMarkAboveAsRead = onMarkAboveAsRead,
-            onMarkBelowAsRead = onMarkBelowAsRead,
-            onShareItem = onShareItem,
-            onToggleBookmark = onToggleBookmark,
-            dropDownMenuExpanded = dropDownMenuExpanded,
-            onDismissDropdown = onDismissDropdown,
-            maxLines = maxLines,
-            showOnlyTitle = showOnlyTitle,
-            showReadingTime = showReadingTime,
-        )
+    Surface {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier =
+                modifier
+                    .requiredHeightIn(min = minimumTouchSize)
+                    .padding(vertical = 8.dp, horizontal = LocalDimens.current.margin),
+        ) {
+            FeedItemEitherIndicator(
+                bookmarked = item.bookmarked && bookmarkIndicator,
+                itemImage = null,
+                feedImageUrl = item.feedImageUrl?.toString(),
+                size = 24.dp,
+            )
+            FeedItemText(
+                item = item,
+                onMarkAboveAsRead = onMarkAboveAsRead,
+                onMarkBelowAsRead = onMarkBelowAsRead,
+                onShareItem = onShareItem,
+                onToggleBookmark = onToggleBookmark,
+                dropDownMenuExpanded = dropDownMenuExpanded,
+                onDismissDropdown = onDismissDropdown,
+                maxLines = maxLines,
+                showOnlyTitle = showOnlyTitle,
+                showReadingTime = showReadingTime,
+            )
+        }
     }
 }
 
 @Composable
-@Preview(showBackground = true)
+@PreviewLightDark
 private fun PreviewRead() {
     PreviewTheme {
-        Surface {
-            FeedItemSuperCompact(
-                item =
-                    @Suppress("ktlint:standard:max-line-length")
-                    FeedListItem(
-                        title = "title",
-                        snippet = "snippet which is quite long as you might expect from a snipper of a story. It keeps going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and snowing",
-                        feedTitle = "Super Duper Feed One two three hup di too dasf",
-                        pubDate = "Jun 9, 2021",
-                        unread = false,
-                        image = null,
-                        link = null,
-                        id = ID_UNSET,
-                        bookmarked = true,
-                        feedImageUrl = null,
-                        primarySortTime = Instant.EPOCH,
-                        rawPubDate = null,
-                        wordCount = 900,
-                    ),
-                onMarkAboveAsRead = {},
-                onMarkBelowAsRead = {},
-                onShareItem = {},
-                onToggleBookmark = {},
-                dropDownMenuExpanded = false,
-                onDismissDropdown = {},
-                bookmarkIndicator = true,
-                maxLines = 2,
-                showOnlyTitle = false,
-                showReadingTime = true,
-            )
-        }
+        FeedItemSuperCompact(
+            item =
+                @Suppress("ktlint:standard:max-line-length")
+                FeedListItem(
+                    title = "title",
+                    snippet = "snippet which is quite long as you might expect from a snipper of a story. It keeps going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and snowing",
+                    feedTitle = "Super Duper Feed One two three hup di too dasf",
+                    pubDate = "Jun 9, 2021",
+                    unread = false,
+                    image = null,
+                    link = null,
+                    id = ID_UNSET,
+                    bookmarked = true,
+                    feedImageUrl = null,
+                    primarySortTime = Instant.EPOCH,
+                    rawPubDate = null,
+                    wordCount = 900,
+                ),
+            onMarkAboveAsRead = {},
+            onMarkBelowAsRead = {},
+            onShareItem = {},
+            onToggleBookmark = {},
+            dropDownMenuExpanded = false,
+            onDismissDropdown = {},
+            bookmarkIndicator = true,
+            maxLines = 2,
+            showOnlyTitle = false,
+            showReadingTime = true,
+        )
     }
 }
 
 @Composable
-@Preview(showBackground = true)
+@PreviewLightDark
 private fun PreviewUnread() {
     PreviewTheme {
-        Surface {
-            FeedItemSuperCompact(
-                item =
-                    @Suppress("ktlint:standard:max-line-length")
-                    FeedListItem(
-                        title = "title",
-                        snippet = "snippet which is quite long as you might expect from a snipper of a story. It keeps going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and snowing",
-                        feedTitle = "Super Duper Feed One two three hup di too dasf",
-                        pubDate = "Jun 9, 2021",
-                        unread = true,
-                        image = null,
-                        link = null,
-                        id = ID_UNSET,
-                        bookmarked = false,
-                        feedImageUrl = null,
-                        primarySortTime = Instant.EPOCH,
-                        rawPubDate = null,
-                        wordCount = 900,
-                    ),
-                onMarkAboveAsRead = {},
-                onMarkBelowAsRead = {},
-                onShareItem = {},
-                onToggleBookmark = {},
-                dropDownMenuExpanded = false,
-                onDismissDropdown = {},
-                bookmarkIndicator = true,
-                maxLines = 2,
-                showOnlyTitle = false,
-                showReadingTime = true,
-            )
-        }
+        FeedItemSuperCompact(
+            item =
+                @Suppress("ktlint:standard:max-line-length")
+                FeedListItem(
+                    title = "title",
+                    snippet = "snippet which is quite long as you might expect from a snipper of a story. It keeps going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and snowing",
+                    feedTitle = "Super Duper Feed One two three hup di too dasf",
+                    pubDate = "Jun 9, 2021",
+                    unread = true,
+                    image = null,
+                    link = null,
+                    id = ID_UNSET,
+                    bookmarked = false,
+                    feedImageUrl = null,
+                    primarySortTime = Instant.EPOCH,
+                    rawPubDate = null,
+                    wordCount = 900,
+                ),
+            onMarkAboveAsRead = {},
+            onMarkBelowAsRead = {},
+            onShareItem = {},
+            onToggleBookmark = {},
+            dropDownMenuExpanded = false,
+            onDismissDropdown = {},
+            bookmarkIndicator = true,
+            maxLines = 2,
+            showOnlyTitle = false,
+            showReadingTime = true,
+        )
     }
 }
 
 @Composable
-@Preview(showBackground = true)
+@PreviewLightDark
 private fun PreviewWithImage() {
     PreviewTheme {
-        Surface {
-            FeedItemSuperCompact(
-                item =
-                    @Suppress("ktlint:standard:max-line-length")
-                    FeedListItem(
-                        title = "title",
-                        snippet = "snippet which is quite long as you might expect from a snipper of a story. It keeps going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and snowing",
-                        feedTitle = "Super Duper Feed One two three hup di too dasf",
-                        pubDate = "Jun 9, 2021",
-                        unread = true,
-                        image = MediaImage("blabla"),
-                        link = null,
-                        id = ID_UNSET,
-                        bookmarked = false,
-                        feedImageUrl = URL("https://example.com/image.png"),
-                        primarySortTime = Instant.EPOCH,
-                        rawPubDate = null,
-                        wordCount = 900,
-                    ),
-                onMarkAboveAsRead = {},
-                onMarkBelowAsRead = {},
-                onShareItem = {},
-                onToggleBookmark = {},
-                dropDownMenuExpanded = false,
-                onDismissDropdown = {},
-                bookmarkIndicator = true,
-                maxLines = 2,
-                showOnlyTitle = false,
-                showReadingTime = true,
-            )
-        }
+        FeedItemSuperCompact(
+            item =
+                @Suppress("ktlint:standard:max-line-length")
+                FeedListItem(
+                    title = "title",
+                    snippet = "snippet which is quite long as you might expect from a snipper of a story. It keeps going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and snowing",
+                    feedTitle = "Super Duper Feed One two three hup di too dasf",
+                    pubDate = "Jun 9, 2021",
+                    unread = true,
+                    image = MediaImage("blabla"),
+                    link = null,
+                    id = ID_UNSET,
+                    bookmarked = false,
+                    feedImageUrl = URL("https://example.com/image.png"),
+                    primarySortTime = Instant.EPOCH,
+                    rawPubDate = null,
+                    wordCount = 900,
+                ),
+            onMarkAboveAsRead = {},
+            onMarkBelowAsRead = {},
+            onShareItem = {},
+            onToggleBookmark = {},
+            dropDownMenuExpanded = false,
+            onDismissDropdown = {},
+            bookmarkIndicator = true,
+            maxLines = 2,
+            showOnlyTitle = false,
+            showReadingTime = true,
+        )
     }
 }

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedItemSuperCompact.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedItemSuperCompact.kt
@@ -33,14 +33,11 @@ fun FeedItemSuperCompact(
     showReadingTime: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    Surface {
+    Surface(modifier = modifier.requiredHeightIn(min = minimumTouchSize)) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
-            modifier =
-                modifier
-                    .requiredHeightIn(min = minimumTouchSize)
-                    .padding(vertical = 8.dp, horizontal = LocalDimens.current.margin),
+            modifier = Modifier.padding(vertical = 8.dp, horizontal = LocalDimens.current.margin),
         ) {
             FeedItemEitherIndicator(
                 bookmarked = item.bookmarked && bookmarkIndicator,

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
@@ -1341,6 +1341,7 @@ fun FeedListContent(
                                         modifier
                                     }
                                 },
+                        swipeEnabled = !listState.isScrollInProgress
                     )
 
                     if (viewState.feedItemStyle != FeedItemStyle.CARD &&
@@ -1544,6 +1545,7 @@ fun FeedGridContent(
                             } else {
                                 Modifier
                             },
+                        swipeEnabled = !gridState.isScrollInProgress
                     )
                 }
             }

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
@@ -1342,7 +1342,7 @@ fun FeedListContent(
                                         modifier
                                     }
                                 },
-                        swipeEnabled = !listState.isScrollInProgress
+                        swipeEnabled = !listState.isScrollInProgress,
                     )
 
                     if (viewState.feedItemStyle != FeedItemStyle.CARD &&
@@ -1543,12 +1543,11 @@ fun FeedGridContent(
                                                 }
                                             }
                                         }
-                                    }
-                                    .animateItem(fadeInSpec = null, fadeOutSpec = null)
+                                    }.animateItem(fadeInSpec = null, fadeOutSpec = null)
                             } else {
                                 Modifier.animateItem(fadeInSpec = null, fadeOutSpec = null)
                             },
-                        swipeEnabled = !gridState.isScrollInProgress
+                        swipeEnabled = !gridState.isScrollInProgress,
                     )
                 }
             }

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
@@ -1309,7 +1309,7 @@ fun FeedListContent(
                         },
                         modifier =
                             Modifier
-                                .animateItem()
+                                .animateItem(fadeInSpec = null, fadeOutSpec = null)
                                 .safeSemantics {
                                     collectionItemInfo =
                                         CollectionItemInfo(
@@ -1544,9 +1544,9 @@ fun FeedGridContent(
                                             }
                                         }
                                     }
-                                    .animateItem()
+                                    .animateItem(fadeInSpec = null, fadeOutSpec = null)
                             } else {
-                                Modifier.animateItem()
+                                Modifier.animateItem(fadeInSpec = null, fadeOutSpec = null)
                             },
                         swipeEnabled = !gridState.isScrollInProgress
                     )

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
@@ -1309,6 +1309,7 @@ fun FeedListContent(
                         },
                         modifier =
                             Modifier
+                                .animateItem()
                                 .safeSemantics {
                                     collectionItemInfo =
                                         CollectionItemInfo(
@@ -1524,26 +1525,28 @@ fun FeedGridContent(
                         },
                         modifier =
                             if (viewState.markAsReadOnScroll && previewItem.unread) {
-                                Modifier.trackVisibility(0.9f) { info ->
-                                    if (info.isAboveThreshold) {
-                                        // Using itemCoroutineScope because that scope gets destroyed when item scrolls off screen
-                                        // So implicitly, if user is scrolling very fast, the coroutine will be cancelled
-                                        // before marking as read
-                                        itemCoroutineScope.launch {
-                                            delay(REQUIRED_VISIBLE_TIME_FOR_MARK_AS_READ)
-                                            if (viewState.filter.unread) {
-                                                logDebug(LOG_TAG, "Item $itemIndex marking as wasVisible")
-                                                itemWasVisible = true
-                                                // Marks as read in disposable effect
-                                            } else {
-                                                logDebug(LOG_TAG, "Item $itemIndex marking as read")
-                                                markAsUnread(previewItem.id, false)
+                                Modifier
+                                    .trackVisibility(0.9f) { info ->
+                                        if (info.isAboveThreshold) {
+                                            // Using itemCoroutineScope because that scope gets destroyed when item scrolls off screen
+                                            // So implicitly, if user is scrolling very fast, the coroutine will be cancelled
+                                            // before marking as read
+                                            itemCoroutineScope.launch {
+                                                delay(REQUIRED_VISIBLE_TIME_FOR_MARK_AS_READ)
+                                                if (viewState.filter.unread) {
+                                                    logDebug(LOG_TAG, "Item $itemIndex marking as wasVisible")
+                                                    itemWasVisible = true
+                                                    // Marks as read in disposable effect
+                                                } else {
+                                                    logDebug(LOG_TAG, "Item $itemIndex marking as read")
+                                                    markAsUnread(previewItem.id, false)
+                                                }
                                             }
                                         }
                                     }
-                                }
+                                    .animateItem()
                             } else {
-                                Modifier
+                                Modifier.animateItem()
                             },
                         swipeEnabled = !gridState.isScrollInProgress
                     )

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/SwipeableFeedItemPreview.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/SwipeableFeedItemPreview.kt
@@ -1,28 +1,22 @@
 package com.nononsenseapps.feeder.ui.compose.feed
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.FractionalThreshold
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
-import androidx.compose.material.rememberSwipeableState
-import androidx.compose.material.swipeable
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -30,21 +24,15 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.customActions
 import androidx.compose.ui.semantics.stateDescription
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.nononsenseapps.feeder.R
 import com.nononsenseapps.feeder.archmodel.FeedItemStyle
@@ -56,12 +44,7 @@ import com.nononsenseapps.feeder.ui.compose.theme.LocalDimens
 import com.nononsenseapps.feeder.ui.compose.theme.SwipingItemToReadColor
 import com.nononsenseapps.feeder.ui.compose.theme.SwipingItemToUnreadColor
 import com.nononsenseapps.feeder.ui.compose.utils.isCompactLandscape
-import com.nononsenseapps.feeder.util.logDebug
 import kotlinx.coroutines.launch
-import kotlin.math.absoluteValue
-import kotlin.math.roundToInt
-
-private const val LOG_TAG = "FEEDER_SWIPEITEM"
 
 /**
  * OnSwipe takes a boolean parameter of the current read state of the item - so that it can be
@@ -91,14 +74,20 @@ fun SwipeableFeedItemPreview(
     modifier: Modifier = Modifier,
 ) {
     val coroutineScope = rememberCoroutineScope()
-    val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
-    val swipeableState = rememberSwipeableState(initialValue = FeedItemSwipeState.NONE)
-    val onSwipeCallback by rememberUpdatedState(newValue = onSwipe)
+    val swipeableState = rememberSwipeToDismissBoxState(
+        confirmValueChange = {
+            if (it != SwipeToDismissBoxValue.Settled) {
+                onSwipe(item.unread)
+                true
+            } else {
+                false
+            }
+        }
+    )
 
     val color by animateColorAsState(
         targetValue =
             when {
-                swipeableState.targetValue == FeedItemSwipeState.NONE -> Color.Transparent
                 item.unread || filter.onlyUnread -> SwipingItemToReadColor
                 else -> SwipingItemToUnreadColor
             },
@@ -107,22 +96,17 @@ fun SwipeableFeedItemPreview(
 
     LaunchedEffect(filter, item.unread) {
         // critical state changes - reset ui state
-        swipeableState.animateTo(FeedItemSwipeState.NONE)
-    }
-
-    LaunchedEffect(swipeableState.currentValue, swipeableState.isAnimationRunning) {
-        if (!swipeableState.isAnimationRunning && swipeableState.currentValue != FeedItemSwipeState.NONE) {
-            logDebug(LOG_TAG, "onSwipe ${item.unread}")
-            onSwipeCallback(item.unread)
+        if (swipeableState.currentValue != SwipeToDismissBoxValue.Settled) {
+            swipeableState.reset()
         }
     }
 
     var swipeIconAlignment by remember { mutableStateOf(Alignment.CenterStart) }
     // Launched effect because I don't want a value change to zero to change the variable
-    LaunchedEffect(swipeableState.direction) {
-        if (swipeableState.direction == 1f) {
+    LaunchedEffect(swipeableState.dismissDirection) {
+        if (swipeableState.dismissDirection == SwipeToDismissBoxValue.StartToEnd) {
             swipeIconAlignment = Alignment.CenterStart
-        } else if (swipeableState.direction == -1f) {
+        } else if (swipeableState.dismissDirection == SwipeToDismissBoxValue.EndToStart) {
             swipeIconAlignment = Alignment.CenterEnd
         }
     }
@@ -151,8 +135,32 @@ fun SwipeableFeedItemPreview(
     }
 
     val dimens = LocalDimens.current
+    val compactLandscape = isCompactLandscape()
 
-    BoxWithConstraints(
+    // This box handles swiping - it uses padding to allow the nav drawer to still be dragged
+    // It's very important that clickable stuff is handled by its parent - or a direct child
+    // Wrapped in an outer box to get the height set properly
+    SwipeToDismissBox(
+        state = swipeableState,
+        backgroundContent = {
+            Box(
+                contentAlignment = swipeIconAlignment,
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .clip(MaterialTheme.shapes.medium)
+                        .background(color)
+                        .padding(horizontal = 24.dp),
+            ) {
+                Icon(
+                    when (item.unread) {
+                        true -> Icons.Default.VisibilityOff
+                        false -> Icons.Default.Visibility
+                    },
+                    contentDescription = null,
+                )
+            }
+        },
         modifier =
             modifier
                 .width(dimens.maxContentWidth)
@@ -161,7 +169,8 @@ fun SwipeableFeedItemPreview(
                         dropDownMenuExpanded = true
                     },
                     onClick = onItemClick,
-                ).safeSemantics {
+                )
+                .safeSemantics {
                     stateDescription = readStatusLabel
                     customActions =
                         listOf(
@@ -194,48 +203,10 @@ fun SwipeableFeedItemPreview(
                             },
                         )
                 },
+        enableDismissFromStartToEnd = swipeAsRead == SwipeAsRead.FROM_ANYWHERE,
+        enableDismissFromEndToStart = swipeAsRead == SwipeAsRead.FROM_ANYWHERE || swipeAsRead == SwipeAsRead.ONLY_FROM_END,
+        gesturesEnabled = swipeAsRead != SwipeAsRead.DISABLED
     ) {
-        val maxWidthPx =
-            with(LocalDensity.current) {
-                maxWidth.toPx()
-            }
-        Box(
-            contentAlignment = swipeIconAlignment,
-            modifier =
-                Modifier
-                    .matchParentSize()
-                    .background(color)
-                    .padding(horizontal = 24.dp),
-        ) {
-            AnimatedVisibility(
-                visible = swipeableState.targetValue != FeedItemSwipeState.NONE,
-                enter = fadeIn(),
-                exit = fadeOut(),
-            ) {
-                Icon(
-                    when (item.unread) {
-                        true -> Icons.Default.VisibilityOff
-                        false -> Icons.Default.Visibility
-                    },
-                    contentDescription = null,
-                )
-            }
-        }
-
-        val itemAlpha by remember(swipeableState.progress) {
-            derivedStateOf {
-                if (swipeableState.progress.to == FeedItemSwipeState.NONE) {
-                    1f
-                } else if (swipeableState.progress.from != FeedItemSwipeState.NONE) {
-                    0f
-                } else {
-                    (1f - swipeableState.progress.fraction.absoluteValue).coerceIn(0f, 1f)
-                }
-            }
-        }
-
-        val compactLandscape = isCompactLandscape()
-
         when (feedItemStyle) {
             FeedItemStyle.CARD -> {
                 FeedItemCard(
@@ -251,10 +222,6 @@ fun SwipeableFeedItemPreview(
                     maxLines = maxLines,
                     showOnlyTitle = showOnlyTitle,
                     showReadingTime = showReadingTime,
-                    modifier =
-                        Modifier
-                            .offset { IntOffset(swipeableState.offset.value.roundToInt(), 0) }
-                            .graphicsLayer(alpha = itemAlpha),
                 )
             }
 
@@ -269,15 +236,12 @@ fun SwipeableFeedItemPreview(
                             maxLines = maxLines,
                             showReadingTime = showReadingTime,
                         ),
-                    modifier =
-                        Modifier
-                            .offset { IntOffset(swipeableState.offset.value.roundToInt(), 0) }
-                            .graphicsLayer(alpha = itemAlpha),
                     onEvent = { event ->
                         when (event) {
                             FeedItemEvent.DismissDropdown -> {
                                 dropDownMenuExpanded = false
                             }
+
                             FeedItemEvent.MarkAboveAsRead -> onMarkAboveAsRead()
                             FeedItemEvent.MarkBelowAsRead -> onMarkBelowAsRead()
                             FeedItemEvent.ShareItem -> onShareItem()
@@ -301,10 +265,6 @@ fun SwipeableFeedItemPreview(
                     maxLines = maxLines,
                     showOnlyTitle = showOnlyTitle,
                     showReadingTime = showReadingTime,
-                    modifier =
-                        Modifier
-                            .offset { IntOffset(swipeableState.offset.value.roundToInt(), 0) }
-                            .graphicsLayer(alpha = itemAlpha),
                     imageWidth =
                         when (compactLandscape) {
                             true -> 196.dp
@@ -326,70 +286,8 @@ fun SwipeableFeedItemPreview(
                     maxLines = maxLines,
                     showOnlyTitle = showOnlyTitle,
                     showReadingTime = showReadingTime,
-                    modifier =
-                        Modifier
-                            .offset { IntOffset(swipeableState.offset.value.roundToInt(), 0) }
-                            .graphicsLayer(alpha = itemAlpha),
-                )
-            }
-        }
-
-        // This box handles swiping - it uses padding to allow the nav drawer to still be dragged
-        // It's very important that clickable stuff is handled by its parent - or a direct child
-        // Wrapped in an outer box to get the height set properly
-        if (swipeAsRead != SwipeAsRead.DISABLED) {
-            Box(
-                modifier =
-                    Modifier
-                        .matchParentSize(),
-            ) {
-                val anchors = mutableMapOf(0f to FeedItemSwipeState.NONE)
-                Box(
-                    modifier =
-                        Modifier
-                            .run {
-                                @Suppress("KotlinConstantConditions")
-                                when (swipeAsRead) {
-                                    // This never actually gets called due to outer if
-                                    SwipeAsRead.DISABLED ->
-                                        this
-                                            .height(0.dp)
-                                            .width(0.dp)
-
-                                    SwipeAsRead.ONLY_FROM_END -> {
-                                        anchors[-maxWidthPx] = FeedItemSwipeState.LEFT
-                                        this
-                                            .fillMaxHeight()
-                                            .width(this@BoxWithConstraints.maxWidth / 4)
-                                            .align(Alignment.CenterEnd)
-                                    }
-
-                                    SwipeAsRead.FROM_ANYWHERE -> {
-                                        anchors[-maxWidthPx] = FeedItemSwipeState.LEFT
-                                        anchors[maxWidthPx] = FeedItemSwipeState.RIGHT
-                                        this
-                                            .padding(start = 48.dp)
-                                            .matchParentSize()
-                                    }
-                                }
-                            }.swipeable(
-                                state = swipeableState,
-                                anchors = anchors,
-                                orientation = Orientation.Horizontal,
-                                reverseDirection = isRtl,
-                                velocityThreshold = 1000.dp,
-                                thresholds = { _, _ ->
-                                    FractionalThreshold(0.50f)
-                                },
-                            ),
                 )
             }
         }
     }
-}
-
-enum class FeedItemSwipeState {
-    NONE,
-    LEFT,
-    RIGHT,
 }

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/SwipeableFeedItemPreview.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/SwipeableFeedItemPreview.kt
@@ -1,6 +1,8 @@
 package com.nononsenseapps.feeder.ui.compose.feed
 
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -31,6 +33,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -129,6 +132,12 @@ fun SwipeableFeedItemPreview(
         label = "swipeBackground",
     )
 
+    val alpha by animateFloatAsState(
+        targetValue = if (thresholdReached) 1.0f else 0.2f,
+        animationSpec = tween(),
+        label = "alphaAnimation",
+    )
+
     LaunchedEffect(filter, item.unread) {
         // critical state changes - reset ui state
         if (swipeableState.currentValue != SwipeToDismissBoxValue.Settled) {
@@ -186,7 +195,9 @@ fun SwipeableFeedItemPreview(
                                     FeedItemStyle.COMPACT, FeedItemStyle.SUPER_COMPACT -> RectangleShape
                                     else -> MaterialTheme.shapes.medium
                                 },
-                        ).drawBehind {
+                        ).graphicsLayer {
+                            this.alpha = alpha
+                        }.drawBehind {
                             drawRect(color = color)
                         }.padding(horizontal = 24.dp),
             ) {

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/SwipeableFeedItemPreview.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/SwipeableFeedItemPreview.kt
@@ -77,16 +77,15 @@ fun SwipeableFeedItemPreview(
     swipeEnabled: Boolean = true,
 ) {
     val coroutineScope = rememberCoroutineScope()
-    val swipeableState = rememberSwipeToDismissBoxState(
-        confirmValueChange = {
+    val swipeableState =
+        rememberSwipeToDismissBoxState(confirmValueChange = {
             if (it != SwipeToDismissBoxValue.Settled) {
                 onSwipe(item.unread)
                 true
             } else {
                 false
             }
-        }
-    )
+        })
 
     val hapticFeedback = LocalHapticFeedback.current
     val density = LocalDensity.current
@@ -102,8 +101,7 @@ fun SwipeableFeedItemPreview(
             } catch (_: IllegalStateException) {
                 false
             }
-        }
-            .distinctUntilChanged()
+        }.distinctUntilChanged()
             .collect { isOverThreshold ->
                 if (isOverThreshold && !thresholdReached) {
                     thresholdReached = true
@@ -174,11 +172,13 @@ fun SwipeableFeedItemPreview(
                 modifier =
                     Modifier
                         .fillMaxSize()
-                        .clip(shape = when (feedItemStyle) {
-                            FeedItemStyle.COMPACT, FeedItemStyle.SUPER_COMPACT -> RectangleShape
-                            else -> MaterialTheme.shapes.medium
-                        })
-                        .background(color)
+                        .clip(
+                            shape =
+                                when (feedItemStyle) {
+                                    FeedItemStyle.COMPACT, FeedItemStyle.SUPER_COMPACT -> RectangleShape
+                                    else -> MaterialTheme.shapes.medium
+                                },
+                        ).background(color)
                         .padding(horizontal = 24.dp),
             ) {
                 Icon(
@@ -198,8 +198,7 @@ fun SwipeableFeedItemPreview(
                         dropDownMenuExpanded = true
                     },
                     onClick = onItemClick,
-                )
-                .safeSemantics {
+                ).safeSemantics {
                     stateDescription = readStatusLabel
                     customActions =
                         listOf(

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/SwipeableFeedItemPreview.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/SwipeableFeedItemPreview.kt
@@ -1,14 +1,12 @@
 package com.nononsenseapps.feeder.ui.compose.feed
 
 import androidx.compose.animation.animateColorAsState
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
@@ -51,10 +49,6 @@ import kotlinx.coroutines.launch
  * OnSwipe takes a boolean parameter of the current read state of the item - so that it can be
  * called multiple times by several DisposableEffects.
  */
-@OptIn(
-    ExperimentalFoundationApi::class,
-    ExperimentalMaterialApi::class,
-)
 @Composable
 fun SwipeableFeedItemPreview(
     onSwipe: (Boolean) -> Unit,
@@ -138,10 +132,6 @@ fun SwipeableFeedItemPreview(
 
     val dimens = LocalDimens.current
     val compactLandscape = isCompactLandscape()
-
-    // This box handles swiping - it uses padding to allow the nav drawer to still be dragged
-    // It's very important that clickable stuff is handled by its parent - or a direct child
-    // Wrapped in an outer box to get the height set properly
     SwipeToDismissBox(
         state = swipeableState,
         backgroundContent = {

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/SwipeableFeedItemPreview.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/SwipeableFeedItemPreview.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.customActions
@@ -149,7 +150,10 @@ fun SwipeableFeedItemPreview(
                 modifier =
                     Modifier
                         .fillMaxSize()
-                        .clip(MaterialTheme.shapes.medium)
+                        .clip(shape = when (feedItemStyle) {
+                            FeedItemStyle.COMPACT, FeedItemStyle.SUPER_COMPACT -> RectangleShape
+                            else -> MaterialTheme.shapes.medium
+                        })
                         .background(color)
                         .padding(horizontal = 24.dp),
             ) {

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/SwipeableFeedItemPreview.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/SwipeableFeedItemPreview.kt
@@ -72,6 +72,7 @@ fun SwipeableFeedItemPreview(
     onShareItem: () -> Unit,
     onItemClick: () -> Unit,
     modifier: Modifier = Modifier,
+    swipeEnabled: Boolean = true,
 ) {
     val coroutineScope = rememberCoroutineScope()
     val swipeableState = rememberSwipeToDismissBoxState(
@@ -205,7 +206,7 @@ fun SwipeableFeedItemPreview(
                 },
         enableDismissFromStartToEnd = swipeAsRead == SwipeAsRead.FROM_ANYWHERE,
         enableDismissFromEndToStart = swipeAsRead == SwipeAsRead.FROM_ANYWHERE || swipeAsRead == SwipeAsRead.ONLY_FROM_END,
-        gesturesEnabled = swipeAsRead != SwipeAsRead.DISABLED
+        gesturesEnabled = swipeAsRead != SwipeAsRead.DISABLED && swipeEnabled,
     ) {
         when (feedItemStyle) {
             FeedItemStyle.CARD -> {


### PR DESCRIPTION
I use Feeder every day and wanted to contribute by improving the swipe to dismiss experience. The changes are as follows:

- Migrated away from using the deprecated `swipeable` modifier to the purpose built M3 control `SwipeToDismissBox`.
- Added lazy layout item animations for improved UX.
- Added haptic feedback so the user knows when they've reached the swipe threshold.
- Tried to reduce accidental swipes (a personal pain point) by disabling swipe gestures when a scroll is detected. This is a common issue in Jetpack Compose but will hopefully be addressed by Google soon through [their work on gesture disambiguation](https://issuetracker.google.com/issues/252334353).