### PR TITLE
fix: fixed favicon lookup for feeds linking to their own RSS URL

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/model/RssLocalSync.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/RssLocalSync.kt
@@ -354,7 +354,8 @@ class RssLocalSync(
                     if (feedSql.imageUrl == null && feedSql.siteFetched == Instant.EPOCH) {
                         val siteUrl =
                             try {
-                                URL(feed.home_page_url)
+                                val url = URL(feed.home_page_url)
+                                URL(url.protocol, url.host, url.port, "")
                             } catch (e: Throwable) {
                                 logDebug(LOG_TAG, "Bad site url: ${feed.home_page_url}", e)
                                 null


### PR DESCRIPTION
Some feeds use <link> pointing to the RSS endpoint instead of the site root.
When fetching site metadata, Feeder currently uses the full URL, which prevents favicon discovery.
This change derives the base site URL (scheme + host) before fetching metadata.