### PR TITLE
fix: invisible SearchBar

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
@@ -499,7 +499,7 @@ fun FeedScreen(
         toolbarActions = {
             if (viewState.searchBarVisible) {
                 SearchBar(
-                    expanded = true,
+                    expanded = false,
                     onExpandedChange = { onShowSearchBar(it) },
                     inputField = {
                         SearchBarDefaults.InputField(


### PR DESCRIPTION
I looked into issue #975 and traced the problem to how the SearchBar expansion state was being handled.

Both the SearchBar and its inputField were configured with expanded = true. This appears to cause the SearchBar to start in an already-expanded state, which results in the search UI being present but not visibly rendered.

Setting SearchBar(expanded = false) while leaving expansion controlled by the inputField restores the expected behavior: the SearchBar is visible in its collapsed state and expands correctly on interaction.

This change only adjusts the initial expansion state and does not alter any search logic.

fixes #975 