### PR TITLE
feat: when YouTube feed is added, suggest additional channel specific feeds

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/searchfeed/SearchFeedViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/searchfeed/SearchFeedViewModel.kt
@@ -55,7 +55,13 @@ class SearchFeedViewModel(
             initialSiteMetaData
                 .onRight { metaData ->
                     metaData.alternateFeedLinks.forEach {
+                        val channelId = YOUTUBE_CHANNELID_REGEX.find(it.link.toString())?.groupValues?.getOrNull(1)
                         emit(Either.Right(it.link))
+                        if (channelId != null) {
+                            emit(Either.Right(URL("https://www.youtube.com/feeds/videos.xml?playlist_id=UULF$channelId")))
+                            emit(Either.Right(URL("https://www.youtube.com/feeds/videos.xml?playlist_id=UUSH$channelId")))
+                            emit(Either.Right(URL("https://www.youtube.com/feeds/videos.xml?playlist_id=UULV$channelId")))
+                        }
                     }
                     if (metaData.alternateFeedLinks.isEmpty()) {
                         emit(Either.Left(NoAlternateFeeds(initialUrl.toString())))
@@ -104,6 +110,7 @@ class SearchFeedViewModel(
 
     companion object {
         const val LOG_TAG = "FEEDER_SearchFeed"
+        val YOUTUBE_CHANNELID_REGEX = Regex("^https?://www\\.youtube\\.com/feeds/videos\\.xml\\?channel_id=UC([-_a-zA-Z0-9]{22})")
     }
 
     suspend fun suggestionsFor(query: String): List<SearchResult> {


### PR DESCRIPTION
If any YouTube channel rss feed is found in the feed search, additional feeds will be suggested for: Videos only, Shorts only and Livestreams only. More info on YouTube playlist prefixes [here](https://stackoverflow.com/a/79656556)

<img width="540" height="1200" alt="feed-search" src="https://github.com/user-attachments/assets/a60bc6d1-7c34-4cdb-a4a5-268274a24973" />
