### PR TITLE
fix: added divider after 'All feeds' and 'Saved articles' in the NavDrawer. 

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/navdrawer/NavDrawer.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/navdrawer/NavDrawer.kt
@@ -438,52 +438,14 @@ private fun AllFeeds(
     unreadCount: Int = 99,
     onItemClick: () -> Unit = {},
 ) {
-    Row(
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        modifier =
-            Modifier
-                .clickable(onClick = onItemClick)
-                .padding(
-                    start = 16.dp,
-                    end = 16.dp,
-                    top = 2.dp,
-                    bottom = 2.dp,
-                ).fillMaxWidth()
-                .height(48.dp),
-    ) {
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxHeight()
-                    .weight(1.0f, fill = true),
-        ) {
-            Text(
-                text = title,
-                maxLines = 1,
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .align(Alignment.CenterStart),
-            )
-        }
-        if (unreadCount > 0) {
-            val unreadLabel =
-                LocalContext.current.resources.getQuantityString(
-                    R.plurals.n_unread_articles,
-                    unreadCount,
-                    unreadCount,
-                )
-            Text(
-                text = "%d".format(LocalConfiguration.current.locales[0], unreadCount),
-                maxLines = 1,
-                modifier =
-                    Modifier.semantics {
-                        contentDescription = unreadLabel
-                    },
-            )
-        }
-    }
+    Feed(
+        title = title,
+        unreadCount = unreadCount,
+        onItemClick = onItemClick,
+        image = {
+            Box(modifier = Modifier.size(24.dp)) {}
+        },
+    )
 }
 
 @Composable


### PR DESCRIPTION
This is much more intuitive, especially for new users.