### PR TITLE
fix: fixed widget not showing any content

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/archmodel/FeedItemStore.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/archmodel/FeedItemStore.kt
@@ -73,6 +73,17 @@ class FeedItemStore(
         return dao.getPreviewsCount(SimpleSQLiteQuery(queryString.toString(), args.toTypedArray()))
     }
 
+    fun getWidgetFeedListItems(
+        feedId: Long,
+        tag: String,
+    ): Flow<List<FeedListItem>> =
+        when {
+            feedId == ID_SAVED_ARTICLES -> dao.widgetPreviewsSaved()
+            feedId > ID_UNSET -> dao.widgetPreviewsByFeed(feedId)
+            tag.isNotEmpty() -> dao.widgetPreviewsByTag(tag)
+            else -> dao.widgetPreviewsAllFeeds()
+        }.map { list -> list.map { it.toFeedListItem() } }
+
     fun getPagedFeedItemsRaw(
         feedId: Long,
         tag: String,

--- a/app/src/main/java/com/nononsenseapps/feeder/archmodel/Repository.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/archmodel/Repository.kt
@@ -400,29 +400,9 @@ class Repository(
         }
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    fun getCurrentWidgetFeedListItems(): Flow<PagingData<FeedListItem>> =
-        combine(
-            currentWidgetFeedAndTag,
-            feedListFilter,
-        ) { feedAndTag, feedListFilter ->
-            val (feedId, tag) = feedAndTag
-            FeedListArgs(
-                feedId = feedId,
-                tag = tag,
-                minReadTime = Instant.EPOCH,
-                newestFirst = true,
-                filter = feedListFilter,
-                search = "",
-            )
-        }.flatMapLatest {
-            feedItemStore.getPagedFeedItemsRaw(
-                feedId = it.feedId,
-                tag = it.tag,
-                minReadTime = it.minReadTime,
-                newestFirst = it.newestFirst,
-                filter = it.filter,
-                search = it.search,
-            )
+    fun getCurrentWidgetFeedListItems(): Flow<List<FeedListItem>> =
+        currentWidgetFeedAndTag.flatMapLatest { (feedId, tag) ->
+            feedItemStore.getWidgetFeedListItems(feedId = feedId, tag = tag)
         }
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/app/src/main/java/com/nononsenseapps/feeder/db/room/FeedItemDao.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/db/room/FeedItemDao.kt
@@ -162,6 +162,57 @@ interface FeedItemDao {
         FROM feed_items
         LEFT JOIN feeds ON feed_items.feed_id = feeds.id
         WHERE feed_id IS :feedId
+          AND block_time IS NULL
+        ORDER BY $FEED_ITEM_LIST_SORT_ORDER_DESC
+        LIMIT 50
+        """,
+    )
+    fun widgetPreviewsByFeed(feedId: Long): Flow<List<PreviewItem>>
+
+    @Query(
+        """
+        SELECT $PREVIEW_COLUMNS
+        FROM feed_items
+        LEFT JOIN feeds ON feed_items.feed_id = feeds.id
+        WHERE tag IS :tag
+          AND block_time IS NULL
+        ORDER BY $FEED_ITEM_LIST_SORT_ORDER_DESC
+        LIMIT 50
+        """,
+    )
+    fun widgetPreviewsByTag(tag: String): Flow<List<PreviewItem>>
+
+    @Query(
+        """
+        SELECT $PREVIEW_COLUMNS
+        FROM feed_items
+        LEFT JOIN feeds ON feed_items.feed_id = feeds.id
+        WHERE block_time IS NULL
+        ORDER BY $FEED_ITEM_LIST_SORT_ORDER_DESC
+        LIMIT 50
+        """,
+    )
+    fun widgetPreviewsAllFeeds(): Flow<List<PreviewItem>>
+
+    @Query(
+        """
+        SELECT $PREVIEW_COLUMNS
+        FROM feed_items
+        LEFT JOIN feeds ON feed_items.feed_id = feeds.id
+        WHERE bookmarked = 1
+          AND block_time IS NULL
+        ORDER BY $FEED_ITEM_LIST_SORT_ORDER_DESC
+        LIMIT 50
+        """,
+    )
+    fun widgetPreviewsSaved(): Flow<List<PreviewItem>>
+
+    @Query(
+        """
+        SELECT $PREVIEW_COLUMNS
+        FROM feed_items
+        LEFT JOIN feeds ON feed_items.feed_id = feeds.id
+        WHERE feed_id IS :feedId
           AND (read_time is null or read_time >= :minReadTime)
           AND bookmarked in (1, :bookmarked)
           AND block_time is null

--- a/app/src/main/java/com/nononsenseapps/feeder/widget/FeedWidget.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/widget/FeedWidget.kt
@@ -19,7 +19,6 @@ import androidx.glance.LocalContext
 import androidx.glance.action.actionStartActivity
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.GlanceAppWidget
-import androidx.glance.appwidget.components.TitleBar
 import androidx.glance.appwidget.lazy.LazyColumn
 import androidx.glance.appwidget.provideContent
 import androidx.glance.background
@@ -30,8 +29,8 @@ import androidx.glance.layout.Column
 import androidx.glance.layout.Row
 import androidx.glance.layout.Spacer
 import androidx.glance.layout.fillMaxHeight
+import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.padding
-import androidx.glance.layout.width
 import androidx.glance.material3.ColorProviders
 import androidx.glance.preview.ExperimentalGlancePreviewApi
 import androidx.glance.state.GlanceStateDefinition
@@ -212,35 +211,55 @@ class FeedWidget : GlanceAppWidget() {
             FeederTitleBar(runSync)
             when (widgetState) {
                 is WidgetState.Syncing -> WidgetSyncingContent()
-                is WidgetState.Ready -> WidgetReadyContent(widgetState.items)
+                is WidgetState.Ready -> {
+                    val pagingItems = flowOf(widgetState.items).collectAsLazyPagingItems()
+                    WidgetReadyContent(pagingItems.itemSnapshotList.items)
+                }
             }
         }
     }
 
     @Composable
     private fun FeederTitleBar(runSync: () -> Unit) {
-        TitleBar(
-            startIcon = ImageProvider(R.drawable.ic_stat_f),
-            title = LocalContext.current.getString(R.string.widget_title),
-            modifier = GlanceModifier.clickable(onClick = actionStartActivity(MainActivity::class.java)),
-            actions = {
+        Row(
+            modifier = GlanceModifier.fillMaxWidth().padding(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Row(
+                modifier =
+                    GlanceModifier
+                        .clickable(onClick = actionStartActivity(MainActivity::class.java)),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
                 Image(
-                    provider = ImageProvider(R.drawable.ic_stat_sync),
+                    provider = ImageProvider(R.drawable.ic_stat_f),
                     contentDescription = null,
-                    colorFilter = ColorFilter.tint(GlanceTheme.colors.onSurface),
-                    modifier = GlanceModifier.clickable(runSync),
                 )
-
-                Spacer(modifier = GlanceModifier.width(8.dp))
-
-                Image(
-                    provider = ImageProvider(R.drawable.ic_settings),
-                    contentDescription = "",
-                    colorFilter = ColorFilter.tint(GlanceTheme.colors.onSurface),
-                    modifier = GlanceModifier.clickable(actionStartActivity(FeedWidgetSettingsActivity::class.java)),
+                Text(
+                    text = LocalContext.current.getString(R.string.widget_title),
+                    style = TextStyle(color = GlanceTheme.colors.onSurface),
                 )
-            },
-        )
+            }
+
+            Spacer(modifier = GlanceModifier.defaultWeight())
+
+            Image(
+                provider = ImageProvider(R.drawable.ic_stat_sync),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(GlanceTheme.colors.onSurface),
+                modifier = GlanceModifier.padding(8.dp).clickable(runSync),
+            )
+
+            Image(
+                provider = ImageProvider(R.drawable.ic_settings),
+                contentDescription = "",
+                colorFilter = ColorFilter.tint(GlanceTheme.colors.onSurface),
+                modifier =
+                    GlanceModifier
+                        .padding(start = 12.dp, end = 12.dp)
+                        .clickable(actionStartActivity(FeedWidgetSettingsActivity::class.java)),
+            )
+        }
     }
 
     @Composable
@@ -254,59 +273,69 @@ class FeedWidget : GlanceAppWidget() {
     }
 
     @Composable
-    private fun WidgetReadyContent(data: PagingData<FeedWidgetItem>) {
-        val items = flowOf(data).collectAsLazyPagingItems()
+    private fun WidgetReadyContent(items: List<FeedWidgetItem>) {
         LazyColumn(modifier = GlanceModifier.padding(start = 12.dp)) {
             items(
-                count = items.itemCount,
-                itemId = { items[it]?.id ?: 0 },
+                count = items.size,
+                itemId = { items[it].id },
             ) { index ->
-                items[index]?.let {
-                    WidgetCard(it)
-                }
+                WidgetCard(items[index])
             }
         }
     }
 
     @Composable
     private fun WidgetCard(item: FeedWidgetItem) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            item.image?.let {
-                Image(ImageProvider(it), contentDescription = null)
-            }
-            Column {
-                Text(
-                    text = item.title,
-                    maxLines = 1,
-                    style =
-                        TextStyle(
-                            fontWeight = FontWeight.Bold,
-                            fontSize = 18.sp,
-                            color = GlanceTheme.colors.onSurface,
-                        ),
-                )
-                Text(
-                    text = item.snippet,
-                    maxLines = 1,
-                    style =
-                        TextStyle(
-                            fontWeight = FontWeight.Normal,
-                            fontSize = 12.sp,
-                            color = GlanceTheme.colors.secondary,
-                        ),
-                )
+        Column(modifier = GlanceModifier.fillMaxWidth().padding(bottom = 8.dp)) {
+            Row(
+                modifier =
+                    GlanceModifier
+                        .fillMaxWidth()
+                        .background(GlanceTheme.colors.surfaceVariant)
+                        .padding(8.dp),
+                verticalAlignment = Alignment.Top,
+            ) {
+                item.image?.let {
+                    Image(ImageProvider(it), contentDescription = null)
+                }
+                Column(modifier = GlanceModifier.padding(start = 8.dp)) {
+                    Text(
+                        text = item.title,
+                        maxLines = 2,
+                        style =
+                            TextStyle(
+                                fontWeight = FontWeight.Bold,
+                                fontSize = 16.sp,
+                                color = GlanceTheme.colors.onSurface,
+                            ),
+                    )
+                    Text(
+                        text = item.snippet,
+                        maxLines = 2,
+                        style =
+                            TextStyle(
+                                fontWeight = FontWeight.Normal,
+                                fontSize = 12.sp,
+                                color = GlanceTheme.colors.secondary,
+                            ),
+                    )
+                }
             }
         }
     }
 
     @Composable
     @OptIn(ExperimentalGlancePreviewApi::class)
-    @androidx.glance.preview.Preview(200, 200)
-    private fun PreviewWidgetContent() {
+    @androidx.glance.preview.Preview(400, 500)
+    internal fun PreviewWidgetContent() {
+        val iconBitmap =
+            Bitmap.createBitmap(200, 200, Bitmap.Config.ARGB_8888).also {
+                android.graphics.Canvas(it).drawColor(android.graphics.Color.rgb(80, 120, 200))
+            }
         val previewItems =
             listOf(
                 FeedWidgetItem(
-                    title = "title",
+                    title = "title which is very long because we have to get enough of the clicks baited in donchaknow",
                     snippet =
                         "snippet which is quite long as you might expect from a snipper of a story. " +
                             "It keeps going and going and going and going and going and going and going and going " +
@@ -316,7 +345,7 @@ class FeedWidget : GlanceAppWidget() {
                     feedTitle = "Super Duper Feed One two three hup di too dasf",
                     pubDate = "Jun 9, 2021",
                     unread = false,
-                    image = Bitmap.createBitmap(200, 200, Bitmap.Config.ARGB_8888),
+                    image = iconBitmap,
                     link = null,
                     id = ID_UNSET,
                     bookmarked = false,
@@ -325,7 +354,33 @@ class FeedWidget : GlanceAppWidget() {
                     rawPubDate = null,
                     wordCount = 900,
                 ),
+                FeedWidgetItem(
+                    title = "Second article with a more reasonable title",
+                    snippet = "A shorter snippet that gets to the point quickly.",
+                    feedTitle = "Another Feed",
+                    pubDate = "Jun 10, 2021",
+                    unread = true,
+                    image = null,
+                    link = null,
+                    id = ID_UNSET + 1,
+                    bookmarked = false,
+                    feedImageUrl = null,
+                    primarySortTime = Instant.EPOCH,
+                    rawPubDate = null,
+                    wordCount = 200,
+                ),
             )
-        WidgetContent(WidgetState.Ready(PagingData.from(previewItems)), {})
+        GlanceTheme(colors = ColorProviders(light = darkColorScheme(), dark = darkColorScheme())) {
+            Column(
+                modifier =
+                    GlanceModifier
+                        .fillMaxHeight()
+                        .background(GlanceTheme.colors.background)
+                        .padding(4.dp),
+            ) {
+                FeederTitleBar({})
+                WidgetReadyContent(previewItems)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/nononsenseapps/feeder/widget/FeedWidget.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/widget/FeedWidget.kt
@@ -283,8 +283,14 @@ class FeedWidget : GlanceAppWidget() {
                         .padding(8.dp),
                 verticalAlignment = Alignment.Top,
             ) {
+                val contentColor =
+                    if (item.unread) GlanceTheme.colors.onSurface else GlanceTheme.colors.onSurfaceVariant
                 item.image?.let {
-                    Image(ImageProvider(it), contentDescription = null)
+                    Image(
+                        provider = ImageProvider(it),
+                        contentDescription = null,
+                        colorFilter = if (item.unread) null else ColorFilter.tint(contentColor),
+                    )
                 }
                 Column(modifier = GlanceModifier.padding(start = 8.dp)) {
                     Text(
@@ -294,7 +300,7 @@ class FeedWidget : GlanceAppWidget() {
                             TextStyle(
                                 fontWeight = FontWeight.Bold,
                                 fontSize = 16.sp,
-                                color = GlanceTheme.colors.onSurface,
+                                color = contentColor,
                             ),
                     )
                     Text(
@@ -304,7 +310,7 @@ class FeedWidget : GlanceAppWidget() {
                             TextStyle(
                                 fontWeight = FontWeight.Normal,
                                 fontSize = 12.sp,
-                                color = GlanceTheme.colors.secondary,
+                                color = contentColor,
                             ),
                     )
                 }
@@ -332,7 +338,7 @@ class FeedWidget : GlanceAppWidget() {
                             "going and going and going and going and going and going and going and going and snowing",
                     feedTitle = "Super Duper Feed One two three hup di too dasf",
                     pubDate = "Jun 9, 2021",
-                    unread = false,
+                    unread = true,
                     image = iconBitmap,
                     link = null,
                     id = ID_UNSET,
@@ -349,6 +355,21 @@ class FeedWidget : GlanceAppWidget() {
                     pubDate = "Jun 10, 2021",
                     unread = true,
                     image = null,
+                    link = null,
+                    id = ID_UNSET + 1,
+                    bookmarked = false,
+                    feedImageUrl = null,
+                    primarySortTime = Instant.EPOCH,
+                    rawPubDate = null,
+                    wordCount = 200,
+                ),
+                FeedWidgetItem(
+                    title = "This item is read",
+                    snippet = "A shorter snippet that gets to the point quickly.",
+                    feedTitle = "Another Feed",
+                    pubDate = "Jun 10, 2021",
+                    unread = false,
+                    image = iconBitmap,
                     link = null,
                     id = ID_UNSET + 1,
                     bookmarked = false,

--- a/app/src/main/java/com/nononsenseapps/feeder/widget/FeedWidget.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/widget/FeedWidget.kt
@@ -5,10 +5,11 @@ import android.graphics.Bitmap
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.datastore.core.DataStore
 import androidx.glance.ColorFilter
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
@@ -22,7 +23,6 @@ import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.lazy.LazyColumn
 import androidx.glance.appwidget.provideContent
 import androidx.glance.background
-import androidx.glance.currentState
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Box
 import androidx.glance.layout.Column
@@ -37,9 +37,6 @@ import androidx.glance.state.GlanceStateDefinition
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
-import androidx.paging.PagingData
-import androidx.paging.compose.collectAsLazyPagingItems
-import androidx.paging.map
 import coil3.imageLoader
 import coil3.request.ImageRequest
 import coil3.request.SuccessResult
@@ -56,15 +53,12 @@ import com.nononsenseapps.feeder.ui.MainActivity
 import com.nononsenseapps.feeder.ui.compose.feed.FeedListItem
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.kodein.di.instance
-import java.io.File
 import java.net.URL
 import java.time.Instant
 import java.time.ZonedDateTime
-import kotlin.getValue
 
 data class FeedWidgetItem(
     val id: Long,
@@ -103,7 +97,7 @@ sealed class WidgetState {
     data object Syncing : WidgetState()
 
     data class Ready(
-        val items: PagingData<FeedWidgetItem>,
+        val items: List<FeedWidgetItem>,
     ) : WidgetState()
 }
 
@@ -115,12 +109,12 @@ object FeederWidgetGlanceColorScheme {
         )
 }
 
-private class WidgetStateDataStore(
-    private val context: Context,
-) : DataStore<WidgetState> {
-    private val app = (context.applicationContext as FeederApplication)
-    private val imageLoader = app.imageLoader
-    private val loadImageBitmap: suspend (String) -> Bitmap? = { url ->
+private fun buildWidgetStateFlow(
+    app: FeederApplication,
+    context: Context,
+): Flow<WidgetState> {
+    val imageLoader = app.imageLoader
+    val loadImageBitmap: suspend (String) -> Bitmap? = { url ->
         val request =
             ImageRequest
                 .Builder(context)
@@ -134,53 +128,41 @@ private class WidgetStateDataStore(
         (imageLoader.execute(request) as? SuccessResult)?.image?.toBitmap(200, 200, Bitmap.Config.RGB_565)
     }
 
-    private val repository: Repository by app.di.instance()
+    val repository: Repository by app.di.instance()
 
-    override val data: Flow<WidgetState>
-        get() =
-            combine(
-                repository.syncWorkerRunning,
-                repository
-                    .getCurrentWidgetFeedListItems()
-                    .map { pagingData ->
-                        pagingData
-                            .map { listItem ->
-                                val bitmap = loadImageBitmap(listItem.feedImageUrl?.toString() ?: "")
-                                listItem.toWidgetItem(bitmap)
-                            }
-                    },
-            ) { syncWorkerRunning, feedWidgetItems ->
-                if (syncWorkerRunning) {
-                    WidgetState.Syncing
-                } else {
-                    WidgetState.Ready(feedWidgetItems)
+    return combine(
+        repository.syncWorkerRunning,
+        repository
+            .getCurrentWidgetFeedListItems()
+            .map { listItems ->
+                buildList {
+                    for (listItem in listItems) {
+                        val bitmap = loadImageBitmap(listItem.feedImageUrl?.toString() ?: "")
+                        add(listItem.toWidgetItem(bitmap))
+                    }
                 }
-            }
-
-    override suspend fun updateData(transform: suspend (t: WidgetState) -> WidgetState): WidgetState = throw NotImplementedError("Widget does not need to update its own data")
+            },
+    ) { syncWorkerRunning, items ->
+        if (syncWorkerRunning) {
+            WidgetState.Syncing
+        } else {
+            WidgetState.Ready(items)
+        }
+    }
 }
 
 class FeedWidget : GlanceAppWidget() {
-    override val stateDefinition: GlanceStateDefinition<WidgetState>
-        get() =
-            object : GlanceStateDefinition<WidgetState> {
-                override suspend fun getDataStore(
-                    context: Context,
-                    fileKey: String,
-                ): DataStore<WidgetState> = WidgetStateDataStore(context)
-
-                override fun getLocation(
-                    context: Context,
-                    fileKey: String,
-                ): File = throw NotImplementedError("Widget does not provide a concrete state file location")
-            }
+    override val stateDefinition: GlanceStateDefinition<*>? = null
 
     override suspend fun provideGlance(
         context: Context,
         id: GlanceId,
     ) {
+        val app = context.applicationContext as FeederApplication
+        val widgetStateFlow = buildWidgetStateFlow(app, context)
+
         provideContent {
-            val app = (context.applicationContext as FeederApplication)
+            val widgetState by widgetStateFlow.collectAsState(initial = WidgetState.Syncing)
             val coroutineScope = rememberCoroutineScope()
             val runSync = {
                 val rssLocalSync by app.di.instance<RssLocalSync>()
@@ -189,7 +171,7 @@ class FeedWidget : GlanceAppWidget() {
             }
             GlanceTheme(colors = FeederWidgetGlanceColorScheme.colors) {
                 WidgetContent(
-                    widgetState = currentState(),
+                    widgetState = widgetState,
                     runSync = runSync,
                 )
             }
@@ -211,10 +193,7 @@ class FeedWidget : GlanceAppWidget() {
             FeederTitleBar(runSync)
             when (widgetState) {
                 is WidgetState.Syncing -> WidgetSyncingContent()
-                is WidgetState.Ready -> {
-                    val pagingItems = flowOf(widgetState.items).collectAsLazyPagingItems()
-                    WidgetReadyContent(pagingItems.itemSnapshotList.items)
-                }
+                is WidgetState.Ready -> WidgetReadyContent(widgetState.items)
             }
         }
     }

--- a/app/src/main/java/com/nononsenseapps/feeder/widget/FeedWidget.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/widget/FeedWidget.kt
@@ -1,7 +1,9 @@
 package com.nononsenseapps.feeder.widget
 
 import android.content.Context
+import android.content.Intent
 import android.graphics.Bitmap
+import android.net.Uri
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
@@ -19,6 +21,7 @@ import androidx.glance.ImageProvider
 import androidx.glance.LocalContext
 import androidx.glance.action.actionStartActivity
 import androidx.glance.action.clickable
+import androidx.glance.appwidget.action.actionStartActivity
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.lazy.LazyColumn
 import androidx.glance.appwidget.provideContent
@@ -51,6 +54,7 @@ import com.nononsenseapps.feeder.db.room.ID_UNSET
 import com.nononsenseapps.feeder.model.RssLocalSync
 import com.nononsenseapps.feeder.ui.MainActivity
 import com.nononsenseapps.feeder.ui.compose.feed.FeedListItem
+import com.nononsenseapps.feeder.util.DEEP_LINK_BASE_URI
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
@@ -270,6 +274,11 @@ class FeedWidget : GlanceAppWidget() {
                 modifier =
                     GlanceModifier
                         .fillMaxWidth()
+                        .clickable(
+                            actionStartActivity(
+                                Intent(Intent.ACTION_VIEW, Uri.parse("$DEEP_LINK_BASE_URI/article/${item.id}")),
+                            ),
+                        )
                         .background(GlanceTheme.colors.surfaceVariant)
                         .padding(8.dp),
                 verticalAlignment = Alignment.Top,


### PR DESCRIPTION
This fixes a number of issues, I would suggest inspecting the changes in commit order.

Probably the most substantial change is to how data is loaded into the widget for fixing #1063. Previously, we were trying to re-use the paging data behavior from the main app, but this isn't really supported by Glance. I removed the DataStore that was intended to hack around this limitation and instead introduced some methods through the Repo stack to load a deterministic subset of feed data (limited to 50 items).

The UX changes include:
1. adding a background to cards to try and differentiate between items
2. aligning the title with the icon
3. allowing text wrapping of the title and description
4. applying a color tint to the read items (though this was the later patch)

Now that the previews are fixed, I can easily show some of these changes 😁 

<img width="441" height="562" alt="image" src="https://github.com/user-attachments/assets/1dac2253-1783-454b-9f98-034afef73865" />
