### PR TITLE
fix: added initial widget state and timeouts for bitmap loading (#1113)

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/widget/FeedWidget.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/widget/FeedWidget.kt
@@ -55,10 +55,14 @@ import com.nononsenseapps.feeder.model.RssLocalSync
 import com.nononsenseapps.feeder.ui.MainActivity
 import com.nononsenseapps.feeder.ui.compose.feed.FeedListItem
 import com.nononsenseapps.feeder.util.DEEP_LINK_BASE_URI
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import org.kodein.di.instance
 import java.net.URL
 import java.time.Instant
@@ -129,7 +133,9 @@ private fun buildWidgetStateFlow(
                 .allowHardware(false)
                 .build()
 
-        (imageLoader.execute(request) as? SuccessResult)?.image?.toBitmap(200, 200, Bitmap.Config.RGB_565)
+        withTimeoutOrNull(1_000L) {
+            (imageLoader.execute(request) as? SuccessResult)?.image?.toBitmap(200, 200, Bitmap.Config.RGB_565)
+        }
     }
 
     val repository: Repository by app.di.instance()
@@ -152,7 +158,8 @@ private fun buildWidgetStateFlow(
         } else {
             WidgetState.Ready(items)
         }
-    }
+    }.onStart { emit(WidgetState.Syncing) }
+        .flowOn(Dispatchers.IO)
 }
 
 class FeedWidget : GlanceAppWidget() {


### PR DESCRIPTION
In https://github.com/spacecowboy/Feeder/issues/1113, I have noticed that my widget for my personal feed after the latest release is loading indefinitely. Since I can't seem to recreate in debug, this is an attempt at a speculative fix but I may continue investigating if I get time. Wonder if something has landed in the working tree that may have affected this that didn't make it into the last release?