### PR TITLE
feat: preserve article scroll position when Android recreates the process

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleScreen.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleScreen.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.runtime.snapshotFlow
 import com.nononsenseapps.feeder.R
 import com.nononsenseapps.feeder.archmodel.TextToDisplay
 import com.nononsenseapps.feeder.db.room.ID_UNSET
@@ -80,6 +81,7 @@ import com.nononsenseapps.feeder.util.ActivityLauncher
 import com.nononsenseapps.feeder.util.stripTrackingParameters
 import com.nononsenseapps.feeder.util.unicodeWrap
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.debounce
 import org.kodein.di.compose.LocalDI
 import org.kodein.di.instance
 import java.time.ZoneId
@@ -102,8 +104,14 @@ fun ArticleScreen(
     val isPagingMode by mavm.isPagingMode.collectAsStateWithLifecycle()
     val isAnimatedPaging by mavm.isAnimatedPaging.collectAsStateWithLifecycle()
 
-    val articleScrollState = rememberScrollState()
+    val articleScrollState = rememberScrollState(initial = viewModel.scrollPosition)
     val coroutineScope = rememberCoroutineScope()
+
+    LaunchedEffect(articleScrollState) {
+        snapshotFlow { articleScrollState.value }
+            .debounce(500)
+            .collect { viewModel.saveScrollPosition(it) }
+    }
 
     LaunchedEffect(Unit) {
         mavm.scrollCommand.collect { direction ->

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleScreen.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
@@ -60,7 +61,6 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.compose.runtime.snapshotFlow
 import com.nononsenseapps.feeder.R
 import com.nononsenseapps.feeder.archmodel.TextToDisplay
 import com.nononsenseapps.feeder.db.room.ID_UNSET

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleScreen.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleScreen.kt
@@ -80,8 +80,8 @@ import com.nononsenseapps.feeder.ui.compose.utils.onKeyEventLikeEscape
 import com.nononsenseapps.feeder.util.ActivityLauncher
 import com.nononsenseapps.feeder.util.stripTrackingParameters
 import com.nononsenseapps.feeder.util.unicodeWrap
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.launch
 import org.kodein.di.compose.LocalDI
 import org.kodein.di.instance
 import java.time.ZoneId

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleViewModel.kt
@@ -75,6 +75,9 @@ class ArticleViewModel(
         state["itemId"]
             ?: throw IllegalArgumentException("Missing itemId in savedState")
 
+    val scrollPosition: Int get() =
+        state["scrollPosition"] ?:0
+
     private val articleFlow =
         repository
             .getArticleFlow(itemId)
@@ -108,6 +111,10 @@ class ArticleViewModel(
         // Using as general loading text
         textToDisplay.update { TextToDisplay.LOADING_FULLTEXT }
         displayFullTextOverride.value = displayFullTextOverride.value?.not() ?: articleFlow.value?.fullTextByDefault?.not() ?: true
+    }
+
+    fun saveScrollPosition(pos: Int) {
+        state["scrollPosition"] = pos
     }
 
     private val isFullText: Boolean

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleViewModel.kt
@@ -76,7 +76,7 @@ class ArticleViewModel(
             ?: throw IllegalArgumentException("Missing itemId in savedState")
 
     val scrollPosition: Int get() =
-        state["scrollPosition"] ?:0
+        state["scrollPosition"] ?: 0
 
     private val articleFlow =
         repository


### PR DESCRIPTION
Feeder on Android seems to lose the scroll position in the currently open article. When reading a long form article in Feeder, if one changes context to another app and Android kills the process the behaviour of Feeder is that it goes back to the feeds index and refreshes the feeds. Which interrupts the reading experience and can be disruptive.

This PR keeps note of where in the article the reader was and preserves that across the process wake cycle.

Preserves scroll position in article, only for curretly opened article, related to feature request #411. In that feature it is suggested that Feeder do that for every article, which would involve storing that state somewhere (probbly in the db). The approach suggested in the PR is only for the currently opened article and needs no database chages/migration.