### PR TITLE
feat: add per-feed article metadata thumbnail enrichment

### DIFF
--- a/app/schemas/com.nononsenseapps.feeder.db.room.AppDatabase/39.json
+++ b/app/schemas/com.nononsenseapps.feeder.db.room.AppDatabase/39.json
@@ -1,0 +1,785 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 39,
+    "identityHash": "6353b9a999bcb121e748b88aafad97f6",
+    "entities": [
+      {
+        "tableName": "feeds",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `custom_title` TEXT NOT NULL, `url` TEXT NOT NULL, `tag` TEXT NOT NULL, `notify` INTEGER NOT NULL, `image_url` TEXT, `last_sync` INTEGER NOT NULL, `response_hash` INTEGER NOT NULL, `fulltext_by_default` INTEGER NOT NULL, `open_articles_with` TEXT NOT NULL, `alternate_id` INTEGER NOT NULL, `currently_syncing` INTEGER NOT NULL, `when_modified` INTEGER NOT NULL, `site_fetched` INTEGER NOT NULL, `skip_duplicates` INTEGER NOT NULL, `retry_after` INTEGER NOT NULL, `summarize_on_open` INTEGER NOT NULL, `fetch_og_images` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customTitle",
+            "columnName": "custom_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notify",
+            "columnName": "notify",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastSync",
+            "columnName": "last_sync",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "responseHash",
+            "columnName": "response_hash",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullTextByDefault",
+            "columnName": "fulltext_by_default",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openArticlesWith",
+            "columnName": "open_articles_with",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alternateId",
+            "columnName": "alternate_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentlySyncing",
+            "columnName": "currently_syncing",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "whenModified",
+            "columnName": "when_modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siteFetched",
+            "columnName": "site_fetched",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skipDuplicates",
+            "columnName": "skip_duplicates",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "retryAfter",
+            "columnName": "retry_after",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summarizeOnOpen",
+            "columnName": "summarize_on_open",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchOgImages",
+            "columnName": "fetch_og_images",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feeds_url",
+            "unique": true,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_feeds_url` ON `${TABLE_NAME}` (`url`)"
+          },
+          {
+            "name": "index_feeds_id_url_title",
+            "unique": true,
+            "columnNames": [
+              "id",
+              "url",
+              "title"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_feeds_id_url_title` ON `${TABLE_NAME}` (`id`, `url`, `title`)"
+          }
+        ]
+      },
+      {
+        "tableName": "feed_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `guid` TEXT NOT NULL, `title` TEXT NOT NULL, `plain_title` TEXT NOT NULL, `plain_snippet` TEXT NOT NULL, `image_url` TEXT, `image_from_body` INTEGER NOT NULL, `enclosure_link` TEXT, `enclosure_type` TEXT, `author` TEXT, `pub_date` TEXT, `link` TEXT, `unread` INTEGER NOT NULL, `notified` INTEGER NOT NULL, `feed_id` INTEGER, `first_synced_time` INTEGER NOT NULL, `primary_sort_time` INTEGER NOT NULL, `pinned` INTEGER NOT NULL, `bookmarked` INTEGER NOT NULL, `fulltext_downloaded` INTEGER NOT NULL, `read_time` INTEGER, `word_count` INTEGER NOT NULL, `word_count_full` INTEGER NOT NULL, `block_time` INTEGER, FOREIGN KEY(`feed_id`) REFERENCES `feeds`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "guid",
+            "columnName": "guid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "plainTitle",
+            "columnName": "plain_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "plainSnippet",
+            "columnName": "plain_snippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailImage",
+            "columnName": "image_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageFromBody",
+            "columnName": "image_from_body",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enclosureLink",
+            "columnName": "enclosure_link",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "enclosureType",
+            "columnName": "enclosure_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pubDate",
+            "columnName": "pub_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "link",
+            "columnName": "link",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "oldUnread",
+            "columnName": "unread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notified",
+            "columnName": "notified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedId",
+            "columnName": "feed_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "firstSyncedTime",
+            "columnName": "first_synced_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "primarySortTime",
+            "columnName": "primary_sort_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "oldPinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarked",
+            "columnName": "bookmarked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullTextDownloaded",
+            "columnName": "fulltext_downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "readTime",
+            "columnName": "read_time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "wordCount",
+            "columnName": "word_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wordCountFull",
+            "columnName": "word_count_full",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "blockTime",
+            "columnName": "block_time",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_items_guid_feed_id",
+            "unique": true,
+            "columnNames": [
+              "guid",
+              "feed_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_feed_items_guid_feed_id` ON `${TABLE_NAME}` (`guid`, `feed_id`)"
+          },
+          {
+            "name": "index_feed_items_feed_id",
+            "unique": false,
+            "columnNames": [
+              "feed_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_items_feed_id` ON `${TABLE_NAME}` (`feed_id`)"
+          },
+          {
+            "name": "index_feed_items_block_time",
+            "unique": false,
+            "columnNames": [
+              "block_time"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_items_block_time` ON `${TABLE_NAME}` (`block_time`)"
+          },
+          {
+            "name": "idx_feed_items_cursor",
+            "unique": true,
+            "columnNames": [
+              "primary_sort_time",
+              "pub_date",
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `idx_feed_items_cursor` ON `${TABLE_NAME}` (`primary_sort_time`, `pub_date`, `id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "feeds",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "feed_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "blocklist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `glob_pattern` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "globPattern",
+            "columnName": "glob_pattern",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_blocklist_glob_pattern",
+            "unique": true,
+            "columnNames": [
+              "glob_pattern"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_blocklist_glob_pattern` ON `${TABLE_NAME}` (`glob_pattern`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_remote",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `url` TEXT NOT NULL, `sync_chain_id` TEXT NOT NULL, `latest_message_timestamp` INTEGER NOT NULL, `device_id` INTEGER NOT NULL, `device_name` TEXT NOT NULL, `secret_key` TEXT NOT NULL, `last_feeds_remote_hash` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncChainId",
+            "columnName": "sync_chain_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latestMessageTimestamp",
+            "columnName": "latest_message_timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceName",
+            "columnName": "device_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "secretKey",
+            "columnName": "secret_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastFeedsRemoteHash",
+            "columnName": "last_feeds_remote_hash",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "read_status_synced",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sync_remote` INTEGER NOT NULL, `feed_item` INTEGER NOT NULL, FOREIGN KEY(`feed_item`) REFERENCES `feed_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`sync_remote`) REFERENCES `sync_remote`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sync_remote",
+            "columnName": "sync_remote",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feed_item",
+            "columnName": "feed_item",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_read_status_synced_feed_item_sync_remote",
+            "unique": true,
+            "columnNames": [
+              "feed_item",
+              "sync_remote"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_read_status_synced_feed_item_sync_remote` ON `${TABLE_NAME}` (`feed_item`, `sync_remote`)"
+          },
+          {
+            "name": "index_read_status_synced_feed_item",
+            "unique": false,
+            "columnNames": [
+              "feed_item"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_read_status_synced_feed_item` ON `${TABLE_NAME}` (`feed_item`)"
+          },
+          {
+            "name": "index_read_status_synced_sync_remote",
+            "unique": false,
+            "columnNames": [
+              "sync_remote"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_read_status_synced_sync_remote` ON `${TABLE_NAME}` (`sync_remote`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "feed_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "feed_item"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sync_remote",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sync_remote"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "remote_read_mark",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sync_remote` INTEGER NOT NULL, `feed_url` TEXT NOT NULL, `guid` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, FOREIGN KEY(`sync_remote`) REFERENCES `sync_remote`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sync_remote",
+            "columnName": "sync_remote",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedUrl",
+            "columnName": "feed_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "guid",
+            "columnName": "guid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_remote_read_mark_sync_remote_feed_url_guid",
+            "unique": true,
+            "columnNames": [
+              "sync_remote",
+              "feed_url",
+              "guid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_remote_read_mark_sync_remote_feed_url_guid` ON `${TABLE_NAME}` (`sync_remote`, `feed_url`, `guid`)"
+          },
+          {
+            "name": "index_remote_read_mark_feed_url_guid",
+            "unique": false,
+            "columnNames": [
+              "feed_url",
+              "guid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_remote_read_mark_feed_url_guid` ON `${TABLE_NAME}` (`feed_url`, `guid`)"
+          },
+          {
+            "name": "index_remote_read_mark_sync_remote",
+            "unique": false,
+            "columnNames": [
+              "sync_remote"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_remote_read_mark_sync_remote` ON `${TABLE_NAME}` (`sync_remote`)"
+          },
+          {
+            "name": "index_remote_read_mark_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_remote_read_mark_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sync_remote",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sync_remote"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "remote_feed",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sync_remote` INTEGER NOT NULL, `url` TEXT NOT NULL, FOREIGN KEY(`sync_remote`) REFERENCES `sync_remote`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncRemote",
+            "columnName": "sync_remote",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_remote_feed_sync_remote_url",
+            "unique": true,
+            "columnNames": [
+              "sync_remote",
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_remote_feed_sync_remote_url` ON `${TABLE_NAME}` (`sync_remote`, `url`)"
+          },
+          {
+            "name": "index_remote_feed_url",
+            "unique": false,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_remote_feed_url` ON `${TABLE_NAME}` (`url`)"
+          },
+          {
+            "name": "index_remote_feed_sync_remote",
+            "unique": false,
+            "columnNames": [
+              "sync_remote"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_remote_feed_sync_remote` ON `${TABLE_NAME}` (`sync_remote`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sync_remote",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sync_remote"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_device",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sync_remote` INTEGER NOT NULL, `device_id` INTEGER NOT NULL, `device_name` TEXT NOT NULL, FOREIGN KEY(`sync_remote`) REFERENCES `sync_remote`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncRemote",
+            "columnName": "sync_remote",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceName",
+            "columnName": "device_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_device_sync_remote_device_id",
+            "unique": true,
+            "columnNames": [
+              "sync_remote",
+              "device_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sync_device_sync_remote_device_id` ON `${TABLE_NAME}` (`sync_remote`, `device_id`)"
+          },
+          {
+            "name": "index_sync_device_sync_remote",
+            "unique": false,
+            "columnNames": [
+              "sync_remote"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_device_sync_remote` ON `${TABLE_NAME}` (`sync_remote`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sync_remote",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sync_remote"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [
+      {
+        "viewName": "feeds_with_items_for_nav_drawer",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS select feeds.id as feed_id, item_id, case when custom_title is '' then title else custom_title end as display_title, tag, image_url, unread, bookmarked\n    from feeds\n    left join (\n        select id as item_id, feed_id, read_time is null as unread, bookmarked\n        from feed_items\n        where block_time is null\n    )\n    ON feeds.id = feed_id"
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6353b9a999bcb121e748b88aafad97f6')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/nononsenseapps/feeder/model/opml/OPMLTest.kt
+++ b/app/src/androidTest/java/com/nononsenseapps/feeder/model/opml/OPMLTest.kt
@@ -816,19 +816,19 @@ private val sampleFile: List<String> =
         </title>
       </head>
       <body>
-        <outline feeder:notify="true" feeder:imageUrl="https://example.com/feedImage.png" feeder:fullTextByDefault="true" feeder:openArticlesWith="reader" feeder:alternateId="true" title="&quot;0&quot;" text="&quot;0&quot;" type="rss" xmlUrl="http://example.com/0/rss.xml"/>
-        <outline feeder:notify="false" feeder:fullTextByDefault="false" feeder:openArticlesWith="" feeder:alternateId="false" title="custom &quot;3&quot;" text="custom &quot;3&quot;" type="rss" xmlUrl="http://example.com/3/rss.xml"/>
-        <outline feeder:notify="false" feeder:fullTextByDefault="false" feeder:openArticlesWith="" feeder:alternateId="false" title="custom &quot;6&quot;" text="custom &quot;6&quot;" type="rss" xmlUrl="http://example.com/6/rss.xml"/>
-        <outline feeder:notify="false" feeder:fullTextByDefault="false" feeder:openArticlesWith="" feeder:alternateId="false" title="custom &quot;9&quot;" text="custom &quot;9&quot;" type="rss" xmlUrl="http://example.com/9/rss.xml"/>
+        <outline feeder:notify="true" feeder:imageUrl="https://example.com/feedImage.png" feeder:fullTextByDefault="true" feeder:openArticlesWith="reader" feeder:alternateId="true" feeder:fetchOgImages="false" title="&quot;0&quot;" text="&quot;0&quot;" type="rss" xmlUrl="http://example.com/0/rss.xml"/>
+        <outline feeder:notify="false" feeder:fullTextByDefault="false" feeder:openArticlesWith="" feeder:alternateId="false" feeder:fetchOgImages="false" title="custom &quot;3&quot;" text="custom &quot;3&quot;" type="rss" xmlUrl="http://example.com/3/rss.xml"/>
+        <outline feeder:notify="false" feeder:fullTextByDefault="false" feeder:openArticlesWith="" feeder:alternateId="false" feeder:fetchOgImages="false" title="custom &quot;6&quot;" text="custom &quot;6&quot;" type="rss" xmlUrl="http://example.com/6/rss.xml"/>
+        <outline feeder:notify="false" feeder:fullTextByDefault="false" feeder:openArticlesWith="" feeder:alternateId="false" feeder:fetchOgImages="false" title="custom &quot;9&quot;" text="custom &quot;9&quot;" type="rss" xmlUrl="http://example.com/9/rss.xml"/>
         <outline title="tag1" text="tag1">
-          <outline feeder:notify="false" feeder:fullTextByDefault="false" feeder:openArticlesWith="" feeder:alternateId="false" title="custom &quot;1&quot;" text="custom &quot;1&quot;" type="rss" xmlUrl="http://example.com/1/rss.xml"/>
-          <outline feeder:notify="false" feeder:fullTextByDefault="false" feeder:openArticlesWith="" feeder:alternateId="false" title="custom &quot;4&quot;" text="custom &quot;4&quot;" type="rss" xmlUrl="http://example.com/4/rss.xml"/>
-          <outline feeder:notify="false" feeder:fullTextByDefault="false" feeder:openArticlesWith="" feeder:alternateId="false" title="custom &quot;7&quot;" text="custom &quot;7&quot;" type="rss" xmlUrl="http://example.com/7/rss.xml"/>
+          <outline feeder:notify="false" feeder:fullTextByDefault="false" feeder:openArticlesWith="" feeder:alternateId="false" feeder:fetchOgImages="false" title="custom &quot;1&quot;" text="custom &quot;1&quot;" type="rss" xmlUrl="http://example.com/1/rss.xml"/>
+          <outline feeder:notify="false" feeder:fullTextByDefault="false" feeder:openArticlesWith="" feeder:alternateId="false" feeder:fetchOgImages="false" title="custom &quot;4&quot;" text="custom &quot;4&quot;" type="rss" xmlUrl="http://example.com/4/rss.xml"/>
+          <outline feeder:notify="false" feeder:fullTextByDefault="false" feeder:openArticlesWith="" feeder:alternateId="false" feeder:fetchOgImages="false" title="custom &quot;7&quot;" text="custom &quot;7&quot;" type="rss" xmlUrl="http://example.com/7/rss.xml"/>
         </outline>
         <outline title="tag2" text="tag2">
-          <outline feeder:notify="false" feeder:fullTextByDefault="false" feeder:openArticlesWith="" feeder:alternateId="false" title="custom &quot;2&quot;" text="custom &quot;2&quot;" type="rss" xmlUrl="http://example.com/2/rss.xml"/>
-          <outline feeder:notify="false" feeder:fullTextByDefault="false" feeder:openArticlesWith="" feeder:alternateId="false" title="custom &quot;5&quot;" text="custom &quot;5&quot;" type="rss" xmlUrl="http://example.com/5/rss.xml"/>
-          <outline feeder:notify="false" feeder:fullTextByDefault="false" feeder:openArticlesWith="" feeder:alternateId="false" title="custom &quot;8&quot;" text="custom &quot;8&quot;" type="rss" xmlUrl="http://example.com/8/rss.xml"/>
+          <outline feeder:notify="false" feeder:fullTextByDefault="false" feeder:openArticlesWith="" feeder:alternateId="false" feeder:fetchOgImages="false" title="custom &quot;2&quot;" text="custom &quot;2&quot;" type="rss" xmlUrl="http://example.com/2/rss.xml"/>
+          <outline feeder:notify="false" feeder:fullTextByDefault="false" feeder:openArticlesWith="" feeder:alternateId="false" feeder:fetchOgImages="false" title="custom &quot;5&quot;" text="custom &quot;5&quot;" type="rss" xmlUrl="http://example.com/5/rss.xml"/>
+          <outline feeder:notify="false" feeder:fullTextByDefault="false" feeder:openArticlesWith="" feeder:alternateId="false" feeder:fetchOgImages="false" title="custom &quot;8&quot;" text="custom &quot;8&quot;" type="rss" xmlUrl="http://example.com/8/rss.xml"/>
         </outline>
         <feeder:settings>
           <feeder:setting key="pref_added_feeder_news" value="true"/>

--- a/app/src/main/java/com/nononsenseapps/feeder/db/Constants.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/db/Constants.kt
@@ -54,6 +54,7 @@ const val COL_SKIP_DUPLICATES = "skip_duplicates"
 const val COL_BLOCK_TIME = "block_time"
 const val COL_RETRY_AFTER = "retry_after"
 const val COL_SUMMARIZE_ON_OPEN = "summarize_on_open"
+const val COL_FETCH_OG_IMAGES = "fetch_og_images"
 
 // year 5000
 val FAR_FUTURE = Instant.ofEpochSecond(95635369646)

--- a/app/src/main/java/com/nononsenseapps/feeder/db/room/AppDatabase.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/db/room/AppDatabase.kt
@@ -54,7 +54,7 @@ private const val LOG_TAG = "FEEDER_APPDB"
     views = [
         FeedsWithItemsForNavDrawer::class,
     ],
-    version = 38,
+    version = 39,
 )
 @TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
@@ -137,6 +137,7 @@ fun getAllMigrations(di: DI) =
         MigrationFrom35To36(di),
         MigrationFrom36To37(di),
         MigrationFrom37To38(di),
+        MIGRATION_38_39,
     )
 
 /*
@@ -198,6 +199,17 @@ class MigrationFrom37To38(
         database.execSQL(
             """
             ALTER TABLE feeds ADD COLUMN summarize_on_open INTEGER NOT NULL DEFAULT 0
+            """.trimIndent(),
+        )
+    }
+}
+
+@Suppress("ClassName")
+object MIGRATION_38_39 : Migration(38, 39) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL(
+            """
+            ALTER TABLE feeds ADD COLUMN fetch_og_images INTEGER NOT NULL DEFAULT 0
             """.trimIndent(),
         )
     }

--- a/app/src/main/java/com/nononsenseapps/feeder/db/room/Feed.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/db/room/Feed.kt
@@ -8,6 +8,7 @@ import androidx.room.PrimaryKey
 import com.nononsenseapps.feeder.db.COL_ALTERNATE_ID
 import com.nononsenseapps.feeder.db.COL_CURRENTLY_SYNCING
 import com.nononsenseapps.feeder.db.COL_CUSTOM_TITLE
+import com.nononsenseapps.feeder.db.COL_FETCH_OG_IMAGES
 import com.nononsenseapps.feeder.db.COL_FULLTEXT_BY_DEFAULT
 import com.nononsenseapps.feeder.db.COL_ID
 import com.nononsenseapps.feeder.db.COL_IMAGEURL
@@ -61,6 +62,7 @@ data class Feed
         // Time when feed is allowed to be synced again earliest, based on retry-after response header
         @ColumnInfo(name = COL_RETRY_AFTER) var retryAfter: Instant = Instant.EPOCH,
         @ColumnInfo(name = COL_SUMMARIZE_ON_OPEN) var summarizeOnOpen: Boolean = false,
+        @ColumnInfo(name = COL_FETCH_OG_IMAGES) var fetchOgImages: Boolean = false,
     ) {
         constructor() : this(id = ID_UNSET)
 

--- a/app/src/main/java/com/nononsenseapps/feeder/db/room/FeedItem.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/db/room/FeedItem.kt
@@ -32,6 +32,7 @@ import com.nononsenseapps.feeder.db.FEED_ITEMS_TABLE_NAME
 import com.nononsenseapps.feeder.model.ParsedArticle
 import com.nononsenseapps.feeder.model.ParsedFeed
 import com.nononsenseapps.feeder.model.ThumbnailImage
+import com.nononsenseapps.feeder.model.ThumbnailImagePolicy
 import com.nononsenseapps.feeder.model.host
 import com.nononsenseapps.feeder.ui.text.HtmlToPlainTextConverter
 import java.net.URI
@@ -154,7 +155,11 @@ data class FeedItem
             this.title = this.plainTitle
             this.plainSnippet = summary
 
-            this.thumbnailImage = entry.image
+            this.thumbnailImage =
+                ThumbnailImagePolicy.applyParsedEntryImage(
+                    current = this.thumbnailImage,
+                    incoming = entry.image,
+                )
             val firstEnclosure = entry.attachments?.firstOrNull()
             this.enclosureLink = firstEnclosure?.url
             this.enclosureType = firstEnclosure?.mime_type?.lowercase()

--- a/app/src/main/java/com/nononsenseapps/feeder/model/FeedParser.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/FeedParser.kt
@@ -313,6 +313,7 @@ private fun FeederGoItem.asParsedArticle() =
         author = author?.asParsedAuthor(),
         tags = categories,
         attachments = enclosures?.map { it.asParsedEnclosure() },
+        hasFeedImage = thumbnail?.fromBody == false,
     )
 
 private fun GoEnclosure.asParsedEnclosure() =

--- a/app/src/main/java/com/nononsenseapps/feeder/model/ParsedArticle.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/ParsedArticle.kt
@@ -14,4 +14,5 @@ data class ParsedArticle(
     val author: ParsedAuthor? = null,
     val tags: List<String>? = null,
     val attachments: List<ParsedEnclosure>? = null,
+    val hasFeedImage: Boolean = false,
 )

--- a/app/src/main/java/com/nononsenseapps/feeder/model/RssLocalSync.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/RssLocalSync.kt
@@ -13,6 +13,7 @@ import com.nononsenseapps.feeder.db.room.ID_UNSET
 import com.nononsenseapps.feeder.sync.SyncRestClient
 import com.nononsenseapps.feeder.util.Either
 import com.nononsenseapps.feeder.util.FilePathProvider
+import com.nononsenseapps.feeder.util.fetchOgImage
 import com.nononsenseapps.feeder.util.flatMap
 import com.nononsenseapps.feeder.util.left
 import com.nononsenseapps.feeder.util.logDebug
@@ -336,6 +337,15 @@ class RssLocalSync(
                                     feedItemSql.updateFromParsedEntry(item, guid, feed)
                                     feedItemSql.feedId = feedSql.id
 
+                                    if (feedSql.fetchOgImages) {
+                                        feedItemSql.thumbnailImage =
+                                            resolveThumbnailImage(
+                                                current = feedItemSql.thumbnailImage,
+                                                articleUrl = item.url,
+                                                hasFeedImage = item.hasFeedImage,
+                                            )
+                                    }
+
                                     if (feedItemSql.guid in alreadyReadGuids) {
                                         // TODO get read time from sync service
                                         feedItemSql.readTime = feedItemSql.readTime ?: Instant.now()
@@ -494,6 +504,31 @@ class RssLocalSync(
                     repository.syncLoadFeeds(retryAfter = Instant.now())
                 }
         }
+
+    /**
+     * Final thumbnail priority policy:
+     * 1) Keep feed-provided thumbnail (media/enclosure/etc) when it's not body-derived.
+     * 2) Otherwise try og:image from article <head>.
+     * 3) If no og:image found, keep current value (body fallback or null).
+     */
+    private suspend fun resolveThumbnailImage(
+        current: ThumbnailImage?,
+        articleUrl: String?,
+        hasFeedImage: Boolean,
+    ): ThumbnailImage? {
+        val url = articleUrl?.trim()?.takeIf { it.isNotEmpty() } ?: return current
+        if (!ThumbnailImagePolicy.shouldFetchOgImage(current, url, hasFeedImage)) return current
+
+        val ogImage =
+            try {
+                okHttpClient.fetchOgImage(url)
+            } catch (e: Exception) {
+                logDebug(LOG_TAG, "Failed to fetch og:image for $url", e)
+                null
+            }
+
+        return ThumbnailImagePolicy.applyOgImage(current, ogImage)
+    }
 
     companion object {
         private const val LOG_TAG = "FEEDER_RssLocalSync"

--- a/app/src/main/java/com/nononsenseapps/feeder/model/ThumbnailImagePolicy.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/ThumbnailImagePolicy.kt
@@ -1,0 +1,49 @@
+package com.nononsenseapps.feeder.model
+
+/**
+ * Centralized rules for picking an article thumbnail across feed parsing and
+ * optional article-page metadata enrichment.
+ */
+internal object ThumbnailImagePolicy {
+    /**
+     * Apply the image coming from the parsed feed entry.
+     *
+     * Feed-provided non-body images are authoritative. If a previous sync already
+     * upgraded the item to a non-body image, keep it unless the feed now provides
+     * its own non-body image. Body-derived images are treated as fallback only.
+     */
+    fun applyParsedEntryImage(
+        current: ThumbnailImage?,
+        incoming: ThumbnailImage?,
+    ): ThumbnailImage? =
+        when {
+            incoming != null && !incoming.fromBody -> incoming
+            current != null && !current.fromBody -> current
+            else -> incoming
+        }
+
+    /**
+     * Only body-derived or missing thumbnails are candidates for og:image
+     * enrichment, and only when there is an article URL and the parsed feed
+     * did not expose its own image candidate.
+     */
+    fun shouldFetchOgImage(
+        current: ThumbnailImage?,
+        articleUrl: String?,
+        hasFeedImage: Boolean,
+    ): Boolean = articleUrl.isNullOrBlank().not() && !hasFeedImage && (current == null || current.fromBody)
+
+    /**
+     * Apply the result of og:image lookup. Existing feed-provided or previously
+     * upgraded non-body images always win.
+     */
+    fun applyOgImage(
+        current: ThumbnailImage?,
+        ogImage: ThumbnailImage?,
+    ): ThumbnailImage? =
+        when {
+            current != null && !current.fromBody -> current
+            ogImage != null -> ogImage
+            else -> current
+        }
+}

--- a/app/src/main/java/com/nononsenseapps/feeder/model/gofeed/GoFeedExtensions.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/gofeed/GoFeedExtensions.kt
@@ -86,7 +86,7 @@ class FeederGoItem(
     val extensions: GoExtensions?
         get() = goItem.extensions
 
-    val thumbnail: ThumbnailImage? by lazy {
+    val feedThumbnail: ThumbnailImage? by lazy {
         val thumbnailCandidates =
             sequence {
                 goItem.image?.let { goImage ->
@@ -122,7 +122,17 @@ class FeederGoItem(
                 }
             }
 
-        val thumbnail = thumbnailCandidates.maxByOrNull { it.width ?: -1 }
+        thumbnailCandidates.maxByOrNull { it.width ?: -1 }
+    }
+
+    val bodyThumbnail: ThumbnailImage? by lazy {
+        // Now we are resolving against original, not the feed
+        val baseUrl: String = linkToHtml(feedBaseUrl, link) ?: feedBaseUrl.toString()
+        findFirstImageInHtml(this.content, baseUrl)
+    }
+
+    val thumbnail: ThumbnailImage? by lazy {
+        val thumbnail = feedThumbnail
 
         if (thumbnail is EnclosureImage && (thumbnail.length == 0L || thumbnail.length > 50_000L)) {
             // Enclosures don't have width/height, so guessing from length
@@ -131,10 +141,7 @@ class FeederGoItem(
             return@lazy thumbnail
         }
 
-        // Now we are resolving against original, not the feed
-        val baseUrl: String = linkToHtml(feedBaseUrl, link) ?: feedBaseUrl.toString()
-
-        findFirstImageInHtml(this.content, baseUrl) ?: thumbnail
+        bodyThumbnail ?: thumbnail
     }
 }
 

--- a/app/src/main/java/com/nononsenseapps/feeder/model/html/LinearStuff.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/html/LinearStuff.kt
@@ -23,6 +23,16 @@ data class LinearArticle(
                 }
             }.flatten()
             .toMap()
+
+    val imageUrls: Set<String> by lazy {
+        buildSet {
+            elements.forEach { element ->
+                element.collectImageUrls(this)
+            }
+        }
+    }
+
+    fun containsImageUrl(url: String): Boolean = url in imageUrls
 }
 
 /**
@@ -40,6 +50,24 @@ fun LinearElement.ids(): Set<String> =
         is LinearTable -> ids
         is LinearVideo -> ids
     }
+
+private fun LinearElement.collectImageUrls(target: MutableSet<String>) {
+    when (this) {
+        is LinearAudio,
+        is LinearText,
+        is LinearVideo,
+        -> Unit
+        is LinearImage -> sources.mapTo(target) { it.imgUri }
+        is LinearBlockQuote -> content.forEach { it.collectImageUrls(target) }
+        is LinearListItem -> content.forEach { it.collectImageUrls(target) }
+        is LinearTable ->
+            cells.values
+                .filterNot { it.isFiller }
+                .forEach { cell ->
+                    cell.content.forEach { it.collectImageUrls(target) }
+                }
+    }
+}
 
 /**
  * Represents a list of items, ordered or unordered

--- a/app/src/main/java/com/nononsenseapps/feeder/model/opml/OpmlPullParser.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/opml/OpmlPullParser.kt
@@ -46,6 +46,8 @@ private const val ATTR_IMAGE_URL = "imageUrl"
 
 private const val ATTR_OPEN_ARTICLES_WITH = "openArticlesWith"
 
+private const val ATTR_FETCH_OG_IMAGES = "fetchOgImages"
+
 private const val TAG_BLOCKED = "blocked"
 
 @Suppress("NAME_SHADOWING")
@@ -291,6 +293,11 @@ class OpmlPullParser(
                                 OPML_FEEDER_NAMESPACE,
                                 ATTR_OPEN_ARTICLES_WITH,
                             ) ?: feed.openArticlesWith,
+                        fetchOgImages =
+                            parser
+                                .getAttributeValue(OPML_FEEDER_NAMESPACE, ATTR_FETCH_OG_IMAGES)
+                                ?.toBoolean()
+                                ?: feed.fetchOgImages,
                         imageUrl =
                             parser
                                 .getAttributeValue(OPML_FEEDER_NAMESPACE, ATTR_IMAGE_URL)

--- a/app/src/main/java/com/nononsenseapps/feeder/model/opml/OpmlWriter.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/opml/OpmlWriter.kt
@@ -241,6 +241,7 @@ abstract class BodyTag(
             fullTextByDefault = feed.fullTextByDefault
             openArticlesWith = feed.openArticlesWith
             alternateId = feed.alternateId
+            fetchOgImages = feed.fetchOgImages
         }
 }
 
@@ -295,6 +296,11 @@ class Outline : BodyTag("outline") {
         get() = attributes["feeder:alternateId"]!!.toBoolean()
         set(value) {
             attributes["feeder:alternateId"] = value.toString()
+        }
+    var fetchOgImages: Boolean
+        get() = attributes["feeder:fetchOgImages"]!!.toBoolean()
+        set(value) {
+            attributes["feeder:fetchOgImages"] = value.toString()
         }
 }
 

--- a/app/src/main/java/com/nononsenseapps/feeder/sync/RestBodies.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/sync/RestBodies.kt
@@ -102,6 +102,7 @@ data class EncryptedFeed(
     val fullTextByDefault: Boolean = false,
     val openArticlesWith: String = OPEN_ARTICLE_WITH_APPLICATION_DEFAULT,
     val alternateId: Boolean = false,
+    val fetchOgImages: Boolean = false,
     val whenModified: Instant = Instant.EPOCH,
 )
 
@@ -115,6 +116,7 @@ fun Feed.toEncryptedFeed(): EncryptedFeed =
         fullTextByDefault = fullTextByDefault,
         openArticlesWith = openArticlesWith,
         alternateId = alternateId,
+        fetchOgImages = fetchOgImages,
         whenModified = whenModified,
     )
 
@@ -128,5 +130,6 @@ fun EncryptedFeed.updateFeedCopy(feed: Feed): Feed =
         fullTextByDefault = fullTextByDefault,
         openArticlesWith = openArticlesWith,
         alternateId = alternateId,
+        fetchOgImages = fetchOgImages,
         whenModified = whenModified,
     )

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/editfeed/CreateFeedScreenViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/editfeed/CreateFeedScreenViewModel.kt
@@ -44,6 +44,7 @@ class CreateFeedScreenViewModel(
     override var articleOpener: String by mutableSavedStateOf(state, "")
     override var alternateId: Boolean by mutableSavedStateOf(state, false)
     override var summarizeOnOpen: Boolean by mutableSavedStateOf(state, false)
+    override var fetchOgImages: Boolean by mutableSavedStateOf(state, false)
     override var allTags: List<String> by mutableStateOf(emptyList())
     override var defaultTitle: String by mutableStateOf(state["feedTitle"] ?: "")
     override var feedImage: String by mutableStateOf(state["feedImage"] ?: "")
@@ -94,6 +95,7 @@ class CreateFeedScreenViewModel(
                         alternateId = alternateId,
                         whenModified = Instant.now(),
                         imageUrl = sloppyLinkToStrictURLOrNull(feedImage),
+                        fetchOgImages = fetchOgImages,
                     ),
                 )
 

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/editfeed/EditFeedScreen.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/editfeed/EditFeedScreen.kt
@@ -502,6 +502,13 @@ fun ColumnScope.RightContent(
         icon = null,
     )
     SwitchSetting(
+        title = stringResource(id = R.string.fetch_og_images),
+        checked = viewState.fetchOgImages,
+        { viewState.fetchOgImages = it },
+        description = stringResource(id = R.string.fetch_og_images_desc),
+        icon = null,
+    )
+    SwitchSetting(
         title = stringResource(id = R.string.notify_for_new_items),
         checked = viewState.notify,
         { viewState.notify = it },
@@ -577,6 +584,7 @@ interface EditFeedScreenState {
     var articleOpener: String
     var alternateId: Boolean
     var summarizeOnOpen: Boolean
+    var fetchOgImages: Boolean
     val isOkToSave: Boolean
     val isNotValidUrl: Boolean
     val isOpenItemWithBrowser: Boolean
@@ -610,6 +618,7 @@ private class ScreenState(
     override var articleOpener: String by mutableStateOf("")
     override var alternateId: Boolean by mutableStateOf(false)
     override var summarizeOnOpen: Boolean by mutableStateOf(false)
+    override var fetchOgImages: Boolean by mutableStateOf(false)
 }
 
 @Preview("Edit Feed Phone")

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/editfeed/EditFeedScreenViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/editfeed/EditFeedScreenViewModel.kt
@@ -47,6 +47,7 @@ class EditFeedScreenViewModel(
     override var articleOpener: String by mutableSavedStateOf(state, "")
     override var alternateId: Boolean by mutableSavedStateOf(state, false)
     override var summarizeOnOpen: Boolean by mutableSavedStateOf(state, false)
+    override var fetchOgImages: Boolean by mutableSavedStateOf(state, false)
     override var allTags: List<String> by mutableStateOf(emptyList())
 
     override var feedImage: String by mutableStateOf("")
@@ -112,6 +113,9 @@ class EditFeedScreenViewModel(
             if (!state.contains("summarizeOnOpen")) {
                 summarizeOnOpen = feed.summarizeOnOpen
             }
+            if (!state.contains("fetchOgImages")) {
+                fetchOgImages = feed.fetchOgImages
+            }
 
             repository.allTags
                 .collect { value ->
@@ -138,6 +142,7 @@ class EditFeedScreenViewModel(
                     openArticlesWith = articleOpener,
                     alternateId = alternateId,
                     summarizeOnOpen = summarizeOnOpen,
+                    fetchOgImages = fetchOgImages,
                 )
 
             // No point in doing anything unless they actually differ

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleScreen.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleScreen.kt
@@ -539,6 +539,7 @@ fun ArticleContent(
 
     // Track Y positions of article elements by index for anchor link scrolling
     val elementPositions = remember { mutableMapOf<Int, Float>() }
+    val contentImageUrls = remember(viewState.articleContent) { viewState.articleContent.imageUrls }
 
     ReaderView(
         screenType = screenType,
@@ -576,7 +577,8 @@ fun ArticleContent(
                 else -> null
             },
         image = viewState.image,
-        isFeedText = viewState.textToDisplay == TextToDisplay.CONTENT,
+        showHeaderImage = viewState.textToDisplay == TextToDisplay.CONTENT,
+        contentImageUrls = contentImageUrls,
         modifier = modifier,
         articleScrollState = articleScrollState,
     ) { indexOffset ->

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ReaderView.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ReaderView.kt
@@ -92,7 +92,8 @@ fun ReaderView(
     feedTitle: String,
     authorDate: String?,
     image: ThumbnailImage?,
-    isFeedText: Boolean,
+    showHeaderImage: Boolean,
+    contentImageUrls: Set<String>,
     modifier: Modifier = Modifier,
     articleScrollState: ScrollState = rememberScrollState(),
     articleBody: @Composable (indexOffset: Int) -> Unit,
@@ -290,8 +291,7 @@ fun ReaderView(
                 }
             }
 
-            // Don't show image for full text articles since it's typically inside the full article
-            if (isFeedText && image?.fromBody == false) {
+            if (image != null && shouldShowHeaderImage(showHeaderImage, image, contentImageUrls)) {
                 val imageWidth: Int =
                     if (image.width?.let { it < 640 } == true) {
                         // Zero or too small, do not show
@@ -375,11 +375,18 @@ private fun ReaderPreview() {
                 feedTitle = "Feed Title is here",
                 authorDate = "2018-01-02",
                 image = MediaImage("https://cowboyprogrammer.org/images/2017/10/gimp_image_mode_index.png"),
-                isFeedText = true,
+                showHeaderImage = true,
+                contentImageUrls = emptySet(),
             ) {}
         }
     }
 }
+
+internal fun shouldShowHeaderImage(
+    showHeaderImage: Boolean,
+    image: ThumbnailImage?,
+    contentImageUrls: Set<String>,
+): Boolean = showHeaderImage && image?.fromBody == false && image.url !in contentImageUrls
 
 fun wordsToReadTimeSecs(words: Int): Int = (words * 60 / 220.0).roundToInt()
 

--- a/app/src/main/java/com/nononsenseapps/feeder/util/HtmlUtils.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/util/HtmlUtils.kt
@@ -1,8 +1,17 @@
 package com.nononsenseapps.feeder.util
 
 import com.nononsenseapps.feeder.model.ImageFromHTML
+import com.nononsenseapps.feeder.model.MediaImage
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
 import org.jsoup.Jsoup
 import org.jsoup.parser.Parser.unescapeEntities
+import java.io.IOException
+import java.io.InputStream
+import java.io.InputStreamReader
 
 fun findFirstImageInHtml(
     text: String?,
@@ -33,3 +42,119 @@ fun findFirstImageInHtml(
     } else {
         null
     }
+
+/**
+ * Extract og:image (or twitter:image) from HTML head content.
+ * The [html] should ideally be the `<head>` portion of the page,
+ * but a full page works too — Jsoup will parse either.
+ *
+ * @param html  HTML content (at minimum the `<head>` section)
+ * @param baseUrl base URL for resolving relative URLs
+ * @return a [MediaImage] if a suitable meta image is found, null otherwise
+ */
+fun extractOgImage(
+    html: String,
+    baseUrl: String,
+): MediaImage? {
+    val doc = Jsoup.parse(html, baseUrl)
+
+    // Prefer og:image, fall back to twitter:image
+    val candidates = sequenceOf("og:image", "twitter:image")
+
+    for (property in candidates) {
+        val url =
+            doc
+                .select("meta[property=\"$property\"]")
+                .mapNotNull { it.metaImageUrl() }
+                .firstOrNull { it.isNotBlank() }
+                ?: doc
+                    .select("meta[name=\"$property\"]")
+                    .mapNotNull { it.metaImageUrl() }
+                    .firstOrNull { it.isNotBlank() }
+
+        if (url != null) {
+            return MediaImage(url = url)
+        }
+    }
+
+    return null
+}
+
+private fun org.jsoup.nodes.Element.metaImageUrl(): String? {
+    val rawUrl = attr("content").trim()
+    if (rawUrl.isBlank()) return null
+
+    return absUrl("content").ifBlank { rawUrl }
+}
+
+private fun MediaType.isHtml(): Boolean = subtype == "html" || subtype == "xhtml+xml"
+
+/**
+ * Stream only the `<head>` portion of a web page.
+ * Reads just enough bytes to find `</head>`, keeping network usage minimal
+ * (typically 1–2 KB vs 100+ KB for a full page).
+ */
+internal fun streamHeadContent(inputStream: InputStream): String {
+    val sb = StringBuilder()
+    val reader = InputStreamReader(inputStream, Charsets.UTF_8)
+    val buffer = CharArray(READ_BUFFER_SIZE)
+    val headEndMarker = "</head>"
+
+    reader.use { stream ->
+        while (true) {
+            val read = stream.read(buffer)
+            if (read == -1) break
+
+            sb.append(buffer, 0, read)
+
+            val headEndIndex = sb.toString().indexOf(headEndMarker, ignoreCase = true)
+            if (headEndIndex >= 0) {
+                // Trim to just past </head> — we only need the <head> section
+                sb.setLength(headEndIndex + headEndMarker.length)
+                break
+            }
+
+            // Safety: don't read more than MAX_HEAD_BYTES even without </head>
+            if (sb.length > MAX_HEAD_BYTES) break
+        }
+    }
+
+    return sb.toString()
+}
+
+/**
+ * Fetch a web page's <head> section and extract og:image.
+ * Returns null when no og:image is found or content is not HTML.
+ * Throws [IOException] on network errors or non-2xx responses.
+ */
+internal suspend fun OkHttpClient.fetchOgImage(url: String): MediaImage? =
+    withContext(Dispatchers.IO) {
+        val request =
+            Request
+                .Builder()
+                .url(url)
+                .header("Accept", "text/html")
+                .build()
+
+        val response = newCall(request).execute()
+        response.use {
+            if (!it.isSuccessful) {
+                throw IOException("HTTP ${it.code} fetching og:image for $url")
+            }
+
+            val body = it.body
+            val contentType = body.contentType()
+            if (contentType != null && !contentType.isHtml()) {
+                return@withContext null
+            }
+
+            val headContent = streamHeadContent(body.byteStream())
+
+            if (headContent.isBlank()) return@withContext null
+
+            extractOgImage(headContent, it.request.url.toString())
+        }
+    }
+
+private const val READ_BUFFER_SIZE = 2048
+private const val MAX_HEAD_BYTES = 65536

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -278,6 +278,8 @@
   <string name="skip_duplicate_articles_desc">Articles with links or titles identical to existing articles are ignored</string>
   <string name="summarize">Summarize</string>
   <string name="summarize_on_open">Summarize on open</string>
+  <string name="fetch_og_images">Enhance thumbnails from article metadata</string>
+  <string name="fetch_og_images_desc">Try to improve missing or low-quality thumbnails for this feed</string>
   <string name="openai_settings">AI and translation</string>
   <string name="openai_settings_info">Compatible with many AI providers, but not all</string>
   <string name="summary_api_settings">Summary API</string>

--- a/app/src/test/java/com/nononsenseapps/feeder/db/room/FeedItemUpdateFromParsedEntryTest.kt
+++ b/app/src/test/java/com/nononsenseapps/feeder/db/room/FeedItemUpdateFromParsedEntryTest.kt
@@ -1,0 +1,75 @@
+package com.nononsenseapps.feeder.db.room
+
+import com.nononsenseapps.feeder.model.ImageFromHTML
+import com.nononsenseapps.feeder.model.MediaImage
+import com.nononsenseapps.feeder.model.ParsedArticle
+import com.nononsenseapps.feeder.model.ParsedFeed
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class FeedItemUpdateFromParsedEntryTest {
+    @Test
+    fun keepsExistingNonBodyThumbnailWhenParsedEntryOnlyHasBodyImage() {
+        val existingOgImage = MediaImage(url = "https://example.com/og.jpg")
+        val feedItem = FeedItem(thumbnailImage = existingOgImage)
+
+        feedItem.updateFromParsedEntry(
+            entry =
+                ParsedArticle(
+                    id = "id-1",
+                    image = ImageFromHTML(url = "https://example.com/body.jpg"),
+                ),
+            entryGuid = "guid-1",
+            feed = ParsedFeed(title = "Feed", items = emptyList()),
+        )
+
+        assertEquals(existingOgImage, feedItem.thumbnailImage)
+    }
+
+    @Test
+    fun keepsExistingNonBodyThumbnailWhenParsedEntryHasNoImage() {
+        val existingOgImage = MediaImage(url = "https://example.com/og.jpg")
+        val feedItem = FeedItem(thumbnailImage = existingOgImage)
+
+        feedItem.updateFromParsedEntry(
+            entry = ParsedArticle(id = "id-1"),
+            entryGuid = "guid-1",
+            feed = ParsedFeed(title = "Feed", items = emptyList()),
+        )
+
+        assertEquals(existingOgImage, feedItem.thumbnailImage)
+    }
+
+    @Test
+    fun replacesExistingThumbnailWhenParsedEntryProvidesNonBodyImage() {
+        val existingOgImage = MediaImage(url = "https://example.com/old-og.jpg")
+        val feedProvidedImage = MediaImage(url = "https://example.com/feed.jpg")
+        val feedItem = FeedItem(thumbnailImage = existingOgImage)
+
+        feedItem.updateFromParsedEntry(
+            entry =
+                ParsedArticle(
+                    id = "id-1",
+                    image = feedProvidedImage,
+                ),
+            entryGuid = "guid-1",
+            feed = ParsedFeed(title = "Feed", items = emptyList()),
+        )
+
+        assertEquals(feedProvidedImage, feedItem.thumbnailImage)
+    }
+
+    @Test
+    fun clearsExistingBodyThumbnailWhenParsedEntryHasNoImage() {
+        val feedItem = FeedItem(thumbnailImage = ImageFromHTML(url = "https://example.com/body.jpg"))
+
+        feedItem.updateFromParsedEntry(
+            entry = ParsedArticle(id = "id-1"),
+            entryGuid = "guid-1",
+            feed = ParsedFeed(title = "Feed", items = emptyList()),
+        )
+
+        assertNull(feedItem.thumbnailImage)
+    }
+}

--- a/app/src/test/java/com/nononsenseapps/feeder/model/RssLocalSyncThumbnailPolicyTest.kt
+++ b/app/src/test/java/com/nononsenseapps/feeder/model/RssLocalSyncThumbnailPolicyTest.kt
@@ -1,0 +1,91 @@
+package com.nononsenseapps.feeder.model
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class RssLocalSyncThumbnailPolicyTest {
+    @Test
+    fun keepsFeedProvidedThumbnailEvenWhenOgExists() {
+        val feedImage = MediaImage(url = "https://feed.example.com/feed.jpg")
+        val ogImage = MediaImage(url = "https://site.example.com/og.jpg")
+
+        val result = ThumbnailImagePolicy.applyOgImage(feedImage, ogImage)
+
+        assertEquals(feedImage, result)
+    }
+
+    @Test
+    fun upgradesBodyDerivedThumbnailToOgImageWhenAvailable() {
+        val bodyImage = ImageFromHTML(url = "https://site.example.com/body.jpg")
+        val ogImage = MediaImage(url = "https://site.example.com/og.jpg")
+
+        val result = ThumbnailImagePolicy.applyOgImage(bodyImage, ogImage)
+
+        assertEquals(ogImage, result)
+    }
+
+    @Test
+    fun keepsBodyDerivedThumbnailWhenNoOgImage() {
+        val bodyImage = ImageFromHTML(url = "https://site.example.com/body.jpg")
+
+        val result = ThumbnailImagePolicy.applyOgImage(bodyImage, null)
+
+        assertEquals(bodyImage, result)
+    }
+
+    @Test
+    fun usesOgImageWhenCurrentIsMissing() {
+        val ogImage = MediaImage(url = "https://site.example.com/og.jpg")
+
+        val result = ThumbnailImagePolicy.applyOgImage(null, ogImage)
+
+        assertEquals(ogImage, result)
+    }
+
+    @Test
+    fun returnsNullWhenBothCurrentAndOgAreMissing() {
+        val result = ThumbnailImagePolicy.applyOgImage(null, null)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun keepsExistingNonBodyImageWhenParsedEntryOnlyHasBodyImage() {
+        val existingImage = MediaImage(url = "https://site.example.com/og.jpg")
+        val bodyImage = ImageFromHTML(url = "https://site.example.com/body.jpg")
+
+        val result = ThumbnailImagePolicy.applyParsedEntryImage(existingImage, bodyImage)
+
+        assertEquals(existingImage, result)
+    }
+
+    @Test
+    fun takesIncomingFeedProvidedImageOverExistingNonBodyImage() {
+        val existingImage = MediaImage(url = "https://site.example.com/old-og.jpg")
+        val feedImage = MediaImage(url = "https://feed.example.com/feed.jpg")
+
+        val result = ThumbnailImagePolicy.applyParsedEntryImage(existingImage, feedImage)
+
+        assertEquals(feedImage, result)
+    }
+
+    @Test
+    fun onlyFetchesOgImageForMissingOrBodyDerivedThumbnailsWithoutFeedImage() {
+        val feedImage = MediaImage(url = "https://feed.example.com/feed.jpg")
+        val bodyImage = ImageFromHTML(url = "https://site.example.com/body.jpg")
+
+        assertEquals(false, ThumbnailImagePolicy.shouldFetchOgImage(feedImage, "https://example.com/article", hasFeedImage = false))
+        assertEquals(true, ThumbnailImagePolicy.shouldFetchOgImage(bodyImage, "https://example.com/article", hasFeedImage = false))
+        assertEquals(true, ThumbnailImagePolicy.shouldFetchOgImage(null, "https://example.com/article", hasFeedImage = false))
+        assertEquals(false, ThumbnailImagePolicy.shouldFetchOgImage(bodyImage, null, hasFeedImage = false))
+    }
+
+    @Test
+    fun skipsOgImageWhenFeedAlreadyProvidedAnyThumbnailCandidate() {
+        val bodyImage = ImageFromHTML(url = "https://site.example.com/body.jpg")
+
+        assertEquals(false, ThumbnailImagePolicy.shouldFetchOgImage(bodyImage, "https://example.com/article", hasFeedImage = true))
+        assertEquals(false, ThumbnailImagePolicy.shouldFetchOgImage(null, "https://example.com/article", hasFeedImage = true))
+    }
+}

--- a/app/src/test/java/com/nononsenseapps/feeder/model/gofeed/GoFeedExtensionsKtTest.kt
+++ b/app/src/test/java/com/nononsenseapps/feeder/model/gofeed/GoFeedExtensionsKtTest.kt
@@ -1,6 +1,7 @@
 package com.nononsenseapps.feeder.model.gofeed
 
 import com.nononsenseapps.feeder.model.ImageFromHTML
+import com.nononsenseapps.feeder.model.MediaImage
 import org.junit.Test
 import java.net.URL
 import kotlin.test.assertEquals
@@ -33,5 +34,40 @@ class GoFeedExtensionsKtTest {
         )
 
         assertEquals(expectedSummary, item.snippet)
+    }
+
+    @Test
+    fun feedThumbnailCandidateIsPreservedEvenWhenBodyFallbackIsChosen() {
+        val imageUrl = "https://example.com/feed.jpg"
+        val html = "<img src='$imageUrl' alt='Article image'/>"
+        val item =
+            FeederGoItem(
+                goItem =
+                    makeGoItem(
+                        guid = "$baseUrl/id",
+                        content = html,
+                        description = html,
+                        extensions =
+                            mapOf(
+                                "media" to
+                                    mapOf(
+                                        "content" to
+                                            listOf(
+                                                GoExtension(
+                                                    name = "content",
+                                                    value = null,
+                                                    attrs = mapOf("url" to imageUrl),
+                                                    children = null,
+                                                ),
+                                            ),
+                                    ),
+                            ),
+                    ),
+                feedBaseUrl = baseUrl,
+                feedAuthor = null,
+            )
+
+        assertEquals(MediaImage(url = imageUrl), item.feedThumbnail)
+        assertEquals(ImageFromHTML(url = imageUrl), item.thumbnail)
     }
 }

--- a/app/src/test/java/com/nononsenseapps/feeder/model/html/LinearStuffKtTest.kt
+++ b/app/src/test/java/com/nononsenseapps/feeder/model/html/LinearStuffKtTest.kt
@@ -1,0 +1,136 @@
+package com.nononsenseapps.feeder.model.html
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LinearStuffKtTest {
+    @Test
+    fun imageUrlsIncludesNestedImagesAndAllSourceCandidates() {
+        val directImage =
+            LinearImage(
+                ids = emptySet(),
+                sources =
+                    listOf(
+                        LinearImageSource(
+                            imgUri = "https://example.com/direct.jpg",
+                            widthPx = 1200,
+                            heightPx = 800,
+                            pixelDensity = null,
+                            screenWidth = null,
+                        ),
+                        LinearImageSource(
+                            imgUri = "https://example.com/direct-600.jpg",
+                            widthPx = 600,
+                            heightPx = 400,
+                            pixelDensity = null,
+                            screenWidth = null,
+                        ),
+                    ),
+                caption = null,
+                link = null,
+            )
+        val nestedImage =
+            LinearImage(
+                ids = emptySet(),
+                sources =
+                    listOf(
+                        LinearImageSource(
+                            imgUri = "https://example.com/nested.jpg",
+                            widthPx = 900,
+                            heightPx = 600,
+                            pixelDensity = null,
+                            screenWidth = null,
+                        ),
+                    ),
+                caption = null,
+                link = null,
+            )
+        val tableImage =
+            LinearImage(
+                ids = emptySet(),
+                sources =
+                    listOf(
+                        LinearImageSource(
+                            imgUri = "https://example.com/table.jpg",
+                            widthPx = 700,
+                            heightPx = 500,
+                            pixelDensity = null,
+                            screenWidth = null,
+                        ),
+                    ),
+                caption = null,
+                link = null,
+            )
+
+        val article =
+            LinearArticle(
+                elements =
+                    listOf(
+                        directImage,
+                        LinearListItem(ids = emptySet(), orderedIndex = null, content = listOf(nestedImage)),
+                        LinearTable(
+                            ids = emptySet(),
+                            rowCount = 1,
+                            colCount = 1,
+                            cells =
+                                listOf(
+                                    LinearTableCellItem(
+                                        type = LinearTableCellItemType.DATA,
+                                        colSpan = 1,
+                                        rowSpan = 1,
+                                        content = listOf(tableImage),
+                                    ),
+                                ),
+                            leftToRight = true,
+                        ),
+                    ),
+            )
+
+        assertEquals(
+            setOf(
+                "https://example.com/direct.jpg",
+                "https://example.com/direct-600.jpg",
+                "https://example.com/nested.jpg",
+                "https://example.com/table.jpg",
+            ),
+            article.imageUrls,
+        )
+    }
+
+    @Test
+    fun containsImageUrlMatchesNestedUrls() {
+        val article =
+            LinearArticle(
+                elements =
+                    listOf(
+                        LinearBlockQuote(
+                            ids = emptySet(),
+                            cite = null,
+                            content =
+                                listOf(
+                                    LinearImage(
+                                        ids = emptySet(),
+                                        sources =
+                                            listOf(
+                                                LinearImageSource(
+                                                    imgUri = "https://example.com/hero.jpg",
+                                                    widthPx = 1200,
+                                                    heightPx = 800,
+                                                    pixelDensity = null,
+                                                    screenWidth = null,
+                                                ),
+                                            ),
+                                        caption = null,
+                                        link = null,
+                                    ),
+                                ),
+                        ),
+                    ),
+            )
+
+        assertTrue(article.containsImageUrl("https://example.com/hero.jpg"))
+        assertFalse(article.containsImageUrl("https://example.com/missing.jpg"))
+    }
+}

--- a/app/src/test/java/com/nononsenseapps/feeder/model/opml/OpmlWriterKtTest.kt
+++ b/app/src/test/java/com/nononsenseapps/feeder/model/opml/OpmlWriterKtTest.kt
@@ -40,6 +40,7 @@ class OpmlWriterKtTest {
                         fullTextByDefault = true,
                         openArticlesWith = "reader",
                         alternateId = true,
+                        fetchOgImages = false,
                     )
 
                 result.add(feed)
@@ -72,6 +73,7 @@ class OpmlWriterKtTest {
                         fullTextByDefault = true,
                         openArticlesWith = "reader",
                         alternateId = true,
+                        fetchOgImages = false,
                     )
 
                 result.add(feed)
@@ -92,7 +94,7 @@ class OpmlWriterKtTest {
           </head>
           <body>
             <outline title="quoted &quot;tag&quot;" text="quoted &quot;tag&quot;">
-              <outline feeder:notify="true" feeder:imageUrl="https://example.com/feedImage" feeder:fullTextByDefault="true" feeder:openArticlesWith="reader" feeder:alternateId="true" title="A custom &quot;title&quot; with id &apos;9&apos; &gt; 0 &amp; &lt; 1e" text="A custom &quot;title&quot; with id &apos;9&apos; &gt; 0 &amp; &lt; 1e" type="rss" xmlUrl="http://example.com/rss.xml?format=feed&amp;type=rss"/>
+              <outline feeder:notify="true" feeder:imageUrl="https://example.com/feedImage" feeder:fullTextByDefault="true" feeder:openArticlesWith="reader" feeder:alternateId="true" feeder:fetchOgImages="false" title="A custom &quot;title&quot; with id &apos;9&apos; &gt; 0 &amp; &lt; 1e" text="A custom &quot;title&quot; with id &apos;9&apos; &gt; 0 &amp; &lt; 1e" type="rss" xmlUrl="http://example.com/rss.xml?format=feed&amp;type=rss"/>
             </outline>
           </body>
         </opml>
@@ -109,7 +111,7 @@ class OpmlWriterKtTest {
           </head>
           <body>
             <outline title="news" text="news">
-              <outline feeder:notify="true" feeder:imageUrl="https://example.com/feedImage" feeder:fullTextByDefault="true" feeder:openArticlesWith="reader" feeder:alternateId="true" title="customTitle" text="customTitle" type="rss" xmlUrl="http://example.com/rss.xml?format=feed&amp;type=rss"/>
+              <outline feeder:notify="true" feeder:imageUrl="https://example.com/feedImage" feeder:fullTextByDefault="true" feeder:openArticlesWith="reader" feeder:alternateId="true" feeder:fetchOgImages="false" title="customTitle" text="customTitle" type="rss" xmlUrl="http://example.com/rss.xml?format=feed&amp;type=rss"/>
             </outline>
             <feeder:settings>
               <feeder:setting key="pref_added_feeder_news" value="true"/>

--- a/app/src/test/java/com/nononsenseapps/feeder/sync/EncryptedFeedTest.kt
+++ b/app/src/test/java/com/nononsenseapps/feeder/sync/EncryptedFeedTest.kt
@@ -1,8 +1,10 @@
 package com.nononsenseapps.feeder.sync
 
+import com.nononsenseapps.feeder.db.room.Feed
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 import java.net.URL
+import java.time.Instant
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -30,5 +32,23 @@ class EncryptedFeedTest {
         assertEquals("foo", feed.title)
         assertTrue(feed.alternateId)
         assertFalse(feed.fullTextByDefault)
+        assertFalse(feed.fetchOgImages)
+    }
+
+    @Test
+    fun fetchOgImagesRoundTripsThroughEncryptedFeed() {
+        val original =
+            Feed(
+                url = URL("https://foo.bar"),
+                title = "foo",
+                fetchOgImages = false,
+                whenModified = Instant.now(),
+            )
+
+        val encrypted = original.toEncryptedFeed()
+        val restored = encrypted.updateFeedCopy(Feed())
+
+        assertFalse(encrypted.fetchOgImages)
+        assertFalse(restored.fetchOgImages)
     }
 }

--- a/app/src/test/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ReaderViewKtTest.kt
+++ b/app/src/test/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ReaderViewKtTest.kt
@@ -1,0 +1,53 @@
+package com.nononsenseapps.feeder.ui.compose.feedarticle
+
+import com.nononsenseapps.feeder.model.ImageFromHTML
+import com.nononsenseapps.feeder.model.MediaImage
+import org.junit.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ReaderViewKtTest {
+    @Test
+    fun headerImageIsHiddenWhenReaderIsNotShowingContent() {
+        assertFalse(
+            shouldShowHeaderImage(
+                showHeaderImage = false,
+                image = MediaImage("https://example.com/hero.jpg"),
+                contentImageUrls = emptySet(),
+            ),
+        )
+    }
+
+    @Test
+    fun bodyDerivedImageIsNotShownInHeader() {
+        assertFalse(
+            shouldShowHeaderImage(
+                showHeaderImage = true,
+                image = ImageFromHTML("https://example.com/hero.jpg"),
+                contentImageUrls = emptySet(),
+            ),
+        )
+    }
+
+    @Test
+    fun nonBodyImageIsHiddenWhenAlreadyRenderedInline() {
+        assertFalse(
+            shouldShowHeaderImage(
+                showHeaderImage = true,
+                image = MediaImage("https://example.com/hero.jpg"),
+                contentImageUrls = setOf("https://example.com/hero.jpg"),
+            ),
+        )
+    }
+
+    @Test
+    fun nonBodyImageIsShownWhenNotRenderedInline() {
+        assertTrue(
+            shouldShowHeaderImage(
+                showHeaderImage = true,
+                image = MediaImage("https://example.com/hero.jpg"),
+                contentImageUrls = setOf("https://example.com/other.jpg"),
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/nononsenseapps/feeder/util/ExtractOgImageTest.kt
+++ b/app/src/test/java/com/nononsenseapps/feeder/util/ExtractOgImageTest.kt
@@ -1,0 +1,293 @@
+package com.nononsenseapps.feeder.util
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class ExtractOgImageTest {
+    @Test
+    fun extractsOgImageFromPropertyAttribute() {
+        val html =
+            """
+            <html><head>
+            <meta property="og:image" content="https://example.com/image.jpg">
+            </head><body></body></html>
+            """.trimIndent()
+
+        assertEquals(
+            "https://example.com/image.jpg",
+            extractOgImage(html, "https://example.com/")?.url,
+        )
+    }
+
+    @Test
+    fun extractsOgImageFromNameAttribute() {
+        val html =
+            """
+            <html><head>
+            <meta name="og:image" content="https://example.com/image.jpg">
+            </head><body></body></html>
+            """.trimIndent()
+
+        assertEquals(
+            "https://example.com/image.jpg",
+            extractOgImage(html, "https://example.com/")?.url,
+        )
+    }
+
+    @Test
+    fun prefersPropertyOverNameAttribute() {
+        val html =
+            """
+            <html><head>
+            <meta property="og:image" content="https://example.com/property.jpg">
+            <meta name="og:image" content="https://example.com/name.jpg">
+            </head><body></body></html>
+            """.trimIndent()
+
+        assertEquals(
+            "https://example.com/property.jpg",
+            extractOgImage(html, "https://example.com/")?.url,
+        )
+    }
+
+    @Test
+    fun fallsBackToTwitterImageWhenNoOgImage() {
+        val html =
+            """
+            <html><head>
+            <meta property="twitter:image" content="https://example.com/twitter.jpg">
+            </head><body></body></html>
+            """.trimIndent()
+
+        assertEquals(
+            "https://example.com/twitter.jpg",
+            extractOgImage(html, "https://example.com/")?.url,
+        )
+    }
+
+    @Test
+    fun fallsBackToTwitterImageFromNameAttribute() {
+        val html =
+            """
+            <html><head>
+            <meta name="twitter:image" content="https://example.com/twitter-name.jpg">
+            </head><body></body></html>
+            """.trimIndent()
+
+        assertEquals(
+            "https://example.com/twitter-name.jpg",
+            extractOgImage(html, "https://example.com/")?.url,
+        )
+    }
+
+    @Test
+    fun prefersOgImageOverTwitterImage() {
+        val html =
+            """
+            <html><head>
+            <meta property="og:image" content="https://example.com/og.jpg">
+            <meta property="twitter:image" content="https://example.com/twitter.jpg">
+            </head><body></body></html>
+            """.trimIndent()
+
+        assertEquals(
+            "https://example.com/og.jpg",
+            extractOgImage(html, "https://example.com/")?.url,
+        )
+    }
+
+    @Test
+    fun firstOgImageWinsWhenMultiplePresent() {
+        val html =
+            """
+            <html><head>
+            <meta property="og:image" content="https://example.com/first.jpg">
+            <meta property="og:image" content="https://example.com/second.jpg">
+            </head><body></body></html>
+            """.trimIndent()
+
+        assertEquals(
+            "https://example.com/first.jpg",
+            extractOgImage(html, "https://example.com/")?.url,
+        )
+    }
+
+    @Test
+    fun resolvesRelativeUrlAgainstBaseUrl() {
+        val html =
+            """
+            <html><head>
+            <meta property="og:image" content="/images/thumb.jpg">
+            </head><body></body></html>
+            """.trimIndent()
+
+        assertEquals(
+            "https://example.com/images/thumb.jpg",
+            extractOgImage(html, "https://example.com/article/123")?.url,
+        )
+    }
+
+    @Test
+    fun resolvesProtocolRelativeUrlAgainstBaseUrl() {
+        val html =
+            """
+            <html><head>
+            <meta property="og:image" content="//cdn.example.com/image.jpg">
+            </head><body></body></html>
+            """.trimIndent()
+
+        assertEquals(
+            "https://cdn.example.com/image.jpg",
+            extractOgImage(html, "https://example.com/article")?.url,
+        )
+    }
+
+    @Test
+    fun returnsNullWhenNoMetaTagsPresent() {
+        val html =
+            """
+            <html><head><title>No image here</title></head><body></body></html>
+            """.trimIndent()
+
+        assertNull(extractOgImage(html, "https://example.com/"))
+    }
+
+    @Test
+    fun ignoresBlankOgImageContent() {
+        val html =
+            """
+            <html><head>
+            <meta property="og:image" content="   ">
+            </head><body></body></html>
+            """.trimIndent()
+
+        assertNull(extractOgImage(html, "https://example.com/"))
+    }
+
+    @Test
+    fun ignoresEmptyOgImageContent() {
+        val html =
+            """
+            <html><head>
+            <meta property="og:image" content="">
+            </head><body></body></html>
+            """.trimIndent()
+
+        assertNull(extractOgImage(html, "https://example.com/"))
+    }
+
+    @Test
+    fun returnsNullWhenContentAttributeMissing() {
+        val html =
+            """
+            <html><head>
+            <meta property="og:image">
+            </head><body></body></html>
+            """.trimIndent()
+
+        assertNull(extractOgImage(html, "https://example.com/"))
+    }
+
+    @Test
+    fun blankOgImageFallsBackToTwitterImage() {
+        val html =
+            """
+            <html><head>
+            <meta property="og:image" content="">
+            <meta property="twitter:image" content="https://example.com/twitter.jpg">
+            </head><body></body></html>
+            """.trimIndent()
+
+        assertEquals(
+            "https://example.com/twitter.jpg",
+            extractOgImage(html, "https://example.com/")?.url,
+        )
+    }
+
+    @Test
+    fun handlesUpperCaseMetaTag() {
+        val html =
+            """
+            <html><head>
+            <META PROPERTY="og:image" CONTENT="https://example.com/image.jpg">
+            </head><body></body></html>
+            """.trimIndent()
+
+        assertEquals(
+            "https://example.com/image.jpg",
+            extractOgImage(html, "https://example.com/")?.url,
+        )
+    }
+
+    @Test
+    fun matchesAttributeValueCaseInsensitively() {
+        val html =
+            """
+            <html><head>
+            <meta property="og:Image" content="https://example.com/image.jpg">
+            </head><body></body></html>
+            """.trimIndent()
+
+        assertEquals(
+            "https://example.com/image.jpg",
+            extractOgImage(html, "https://example.com/")?.url,
+        )
+    }
+
+    @Test
+    fun returnedImageIsNotFromBody() {
+        val html =
+            """
+            <html><head>
+            <meta property="og:image" content="https://example.com/image.jpg">
+            </head><body></body></html>
+            """.trimIndent()
+
+        val result = assertNotNull(extractOgImage(html, "https://example.com/"))
+
+        assertEquals("https://example.com/image.jpg", result.url)
+        assertNull(result.width)
+        assertNull(result.height)
+        assertFalse(result.fromBody)
+    }
+
+    @Test
+    fun returnsNullForEmptyHtml() {
+        assertNull(extractOgImage("", "https://example.com/"))
+    }
+
+    @Test
+    fun returnsNullForMinimalHtmlWithNoHead() {
+        assertNull(extractOgImage("<html><body>Hello</body></html>", "https://example.com/"))
+    }
+
+    @Test
+    fun extractsOgImageFromRealisticPage() {
+        val html =
+            """
+            <!DOCTYPE html>
+            <html lang="en">
+            <head>
+                <meta charset="utf-8">
+                <title>Test Article</title>
+                <meta property="og:title" content="Test Article">
+                <meta property="og:description" content="A description">
+                <meta property="og:image" content="https://cdn.example.com/photos/2024/article-hero.jpg">
+                <meta property="og:type" content="article">
+                <meta name="twitter:card" content="summary_large_image">
+                <meta name="twitter:image" content="https://cdn.example.com/photos/2024/article-twitter.jpg">
+                <link rel="stylesheet" href="/style.css">
+            </head>
+            <body><p>Article content</p></body>
+            </html>
+            """.trimIndent()
+
+        assertEquals(
+            "https://cdn.example.com/photos/2024/article-hero.jpg",
+            extractOgImage(html, "https://example.com/article")?.url,
+        )
+    }
+}

--- a/app/src/test/java/com/nononsenseapps/feeder/util/FetchOgImageTest.kt
+++ b/app/src/test/java/com/nononsenseapps/feeder/util/FetchOgImageTest.kt
@@ -1,0 +1,46 @@
+package com.nononsenseapps.feeder.util
+
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class FetchOgImageTest {
+    @Test
+    fun resolvesRelativeOgImageAgainstRedirectTarget() =
+        runBlocking {
+            val originServer = MockWebServer()
+            val destinationServer = MockWebServer()
+
+            try {
+                originServer.start()
+                destinationServer.start()
+
+                destinationServer.enqueue(
+                    MockResponse().setBody(
+                        """
+                        <html><head>
+                        <meta property="og:image" content="/images/hero.jpg">
+                        </head><body></body></html>
+                        """.trimIndent(),
+                    ),
+                )
+                originServer.enqueue(
+                    MockResponse()
+                        .setResponseCode(302)
+                        .addHeader("Location", destinationServer.url("/articles/final")),
+                )
+
+                val image =
+                    OkHttpClient()
+                        .fetchOgImage(originServer.url("/start").toString())
+
+                assertEquals(destinationServer.url("/images/hero.jpg").toString(), image?.url)
+            } finally {
+                originServer.shutdown()
+                destinationServer.shutdown()
+            }
+        }
+}

--- a/app/src/test/java/com/nononsenseapps/feeder/util/StreamHeadContentTest.kt
+++ b/app/src/test/java/com/nononsenseapps/feeder/util/StreamHeadContentTest.kt
@@ -1,0 +1,62 @@
+package com.nononsenseapps.feeder.util
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class StreamHeadContentTest {
+    @Test
+    fun returnsHeadSectionUpToClosingHeadTag() {
+        val html = "<html><head><title>Test</title></head><body>Hello</body></html>"
+        val result = streamHeadContent(html.byteInputStream(Charsets.UTF_8))
+
+        assertEquals("<html><head><title>Test</title></head>", result)
+    }
+
+    @Test
+    fun caseInsensitiveClosingHeadTag() {
+        val html = "<html><head><title>Test</title></HEAD><body>Hello</body></html>"
+        val result = streamHeadContent(html.byteInputStream(Charsets.UTF_8))
+
+        assertEquals("<html><head><title>Test</title></HEAD>", result)
+    }
+
+    @Test
+    fun returnsContentUpToSafetyLimitWhenNoClosingHeadTag() {
+        val headContent = "<html><head><title>No closing head"
+        val padding = "x".repeat(66000 - headContent.length)
+        val html = headContent + padding
+
+        val result = streamHeadContent(html.byteInputStream(Charsets.UTF_8))
+
+        assertTrue(result.length <= 65536 + 2048)
+        assertTrue(result.startsWith(headContent))
+    }
+
+    @Test
+    fun handlesMultiByteUtf8CharactersAcrossBufferBoundary() {
+        val cjkChar = "\u3042"
+        val prefix = "<html><head><title>" + "a".repeat(2047 - "<html><head><title>".length)
+        val suffix = cjkChar + "</head><body></body></html>"
+
+        val html = prefix + suffix
+        val result = streamHeadContent(html.byteInputStream(Charsets.UTF_8))
+
+        assertTrue(result.contains(cjkChar))
+        assertTrue(result.endsWith("</head>"))
+    }
+
+    @Test
+    fun detectsClosingHeadTagSplitAcrossBufferBoundary() {
+        val headOpen = "<html><head><title>"
+        val padLength = 2046 - headOpen.length
+        val padding = "d".repeat(padLength)
+        val html = headOpen + padding + "</head>" + "<body>should-not-appear</body></html>"
+
+        val result = streamHeadContent(html.byteInputStream(Charsets.UTF_8))
+
+        assertTrue(result.endsWith("</head>"))
+        assertFalse(result.contains("should-not-appear"))
+    }
+}


### PR DESCRIPTION
Some feeds have missing thumbnails. This PR adds a per-feed toggle to fetch `og:image`/`twitter:image` from the article page during RSS sync and use it when an item has no better thumbnail. It also avoids duplicate header images in the article reader.

**OG thumbnail enrichment**

New per-feed toggle in feed settings (default OFF): *Enhance thumbnails from article metadata*. When enabled, each synced item that only has a body-extracted image (or no image at all) gets an extra request to the article URL to look for `og:image`/`twitter:image` meta tags. Only the `<head>` section of the page is streamed and the connection is closed as soon as the `</head>` boundary is hit, so no full page body is downloaded.

Feed-provided thumbnails (media/enclosure) are never replaced, and enrichment only applies to items whose displayed thumbnail is missing or body-derived. If a feed provides a thumbnail that is too small to use and the item falls back to a body image, enrichment is still attempted. Once an item has been upgraded to a non-body thumbnail, it won't be fetched again on later syncs. Relative image URLs are resolved against the final redirected page URL and blank metadata values are ignored.

The toggle survives encrypted feed sync and OPML import/export. There is no separate background job; enrichment happens inline during sync.

**Full-text duplicate image fix**

The article reader previously always showed the header thumbnail for non-body images, which could duplicate the same image inline. It now compares the header image URL against the rendered article content and only hides it when that URL already appears inline, so articles that do not duplicate the hero image in their body still keep their header image.

DB version bumped to 39 with a new `feeds.fetch_og_images` column (default 0). Tests cover thumbnail policy, feed item update merging, reader image dedupe, OG image extraction, head-content streaming, and serialization/export coverage for the new field.

Fixes #1125 