### PR TITLE
feat: upgraded export format so saved articles can be imported again

### DIFF
--- a/app/src/androidTest/java/com/nononsenseapps/feeder/model/export/ExportSavedTest.kt
+++ b/app/src/androidTest/java/com/nononsenseapps/feeder/model/export/ExportSavedTest.kt
@@ -17,6 +17,7 @@ import com.nononsenseapps.feeder.db.room.Feed
 import com.nononsenseapps.feeder.db.room.FeedDao
 import com.nononsenseapps.feeder.db.room.FeedItem
 import com.nononsenseapps.feeder.db.room.FeedItemDao
+import com.nononsenseapps.feeder.model.MediaImage
 import com.nononsenseapps.feeder.model.OPMLParserHandler
 import com.nononsenseapps.feeder.model.opml.OPMLImporter
 import com.nononsenseapps.feeder.util.ToastMaker
@@ -109,7 +110,36 @@ class ExportSavedTest : DIAware {
             assertEquals(SAVED_ARTICLES_EXPORT_FORMAT, result.format)
             assertEquals(SAVED_ARTICLES_EXPORT_VERSION, result.version)
             assertEquals(
-                listOf(SavedArticleExportItem("https://example.com/ampersands/1")),
+                listOf(
+                    SavedArticleExportItem(
+                        link = "https://example.com/ampersands/1",
+                        guid = "guid anime2you",
+                        title = "Item with image",
+                        snippet = "Snippet with image",
+                        pubDate = "2026-05-12T08:30Z",
+                        primarySortTime = "2026-05-12T08:29:30Z",
+                        readTime = "2026-05-12T08:31:00Z",
+                        author = "Example Author",
+                        thumbnailImage =
+                            MediaImage(
+                                url = "https://example.com/ampersands/image.png",
+                                width = 640,
+                                height = 320,
+                            ),
+                        enclosureLink = "https://example.com/ampersands/podcast.mp3",
+                        enclosureType = "audio/mpeg",
+                        wordCount = 42,
+                        wordCountFull = 420,
+                        feed =
+                            SavedArticleFeedExportItem(
+                                url = "https://example.com/ampersands",
+                                title = "Ampersands are & the worst",
+                                customTitle = "Ampersands",
+                                tag = "Characters",
+                                fullTextByDefault = true,
+                            ),
+                    ),
+                ),
                 result.articles,
             )
         }
@@ -120,7 +150,10 @@ class ExportSavedTest : DIAware {
             db.feedDao().insertFeed(
                 Feed(
                     title = "Ampersands are & the worst",
+                    customTitle = "Ampersands",
                     url = URL("https://example.com/ampersands"),
+                    tag = "Characters",
+                    fullTextByDefault = true,
                 ),
             )
 
@@ -129,11 +162,22 @@ class ExportSavedTest : DIAware {
                 guid = "guid anime2you",
                 plainTitle = "Item with image",
                 plainSnippet = "Snippet with image",
+                thumbnailImage =
+                    MediaImage(
+                        url = "https://example.com/ampersands/image.png",
+                        width = 640,
+                        height = 320,
+                    ),
+                enclosureLink = "https://example.com/ampersands/podcast.mp3",
+                enclosureType = "audio/mpeg",
+                author = "Example Author",
                 feedId = feedId,
                 link = "https://example.com/ampersands/1",
-                pubDate = ZonedDateTime.now(ZoneOffset.UTC),
-                primarySortTime = Instant.now(),
-                thumbnailImage = null,
+                pubDate = ZonedDateTime.of(2026, 5, 12, 8, 30, 0, 0, ZoneOffset.UTC),
+                primarySortTime = Instant.parse("2026-05-12T08:29:30Z"),
+                readTime = Instant.parse("2026-05-12T08:31:00Z"),
+                wordCount = 42,
+                wordCountFull = 420,
             ),
         )
     }

--- a/app/src/androidTest/java/com/nononsenseapps/feeder/model/export/ExportSavedTest.kt
+++ b/app/src/androidTest/java/com/nononsenseapps/feeder/model/export/ExportSavedTest.kt
@@ -40,6 +40,7 @@ import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import kotlin.random.Random
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
@@ -160,26 +161,88 @@ class ExportSavedTest : DIAware {
     }
 
     private suspend fun insertTestData(): Long {
+        val (itemId, _) = insertTestDataWithFeed()
+        return itemId
+    }
+
+    private suspend fun insertTestDataWithFeed(): Pair<Long, Long> {
         val article = savedArticleExportItem()
         val feedId = insertTestFeed()
-        return db.feedItemDao().insertFeedItem(
-            FeedItem(
-                guid = article.guid,
-                plainTitle = article.title,
-                plainSnippet = article.snippet,
-                thumbnailImage = article.thumbnailImage,
-                enclosureLink = article.enclosureLink,
-                enclosureType = article.enclosureType,
-                author = article.author,
+        val itemId =
+            db.feedItemDao().insertFeedItem(
+                FeedItem(
+                    guid = article.guid,
+                    plainTitle = article.title,
+                    plainSnippet = article.snippet,
+                    thumbnailImage = article.thumbnailImage,
+                    enclosureLink = article.enclosureLink,
+                    enclosureType = article.enclosureType,
+                    author = article.author,
+                    feedId = feedId,
+                    link = article.link,
+                    pubDate = ZonedDateTime.of(2026, 5, 12, 8, 30, 0, 0, ZoneOffset.UTC),
+                    primarySortTime = Instant.parse("2026-05-12T08:29:30Z"),
+                    readTime = Instant.parse("2026-05-12T08:31:00Z"),
+                    wordCount = article.wordCount,
+                    wordCountFull = article.wordCountFull,
+                ),
+            )
+        return itemId to feedId
+    }
+
+    private fun assertSavedArticleRestored(
+        article: SavedArticleExportItem,
+        imported: FeedItem,
+        feedId: Long,
+    ) {
+        assertTrue(imported.bookmarked)
+        assertEquals(article.title, imported.plainTitle)
+        assertEquals(article.snippet, imported.plainSnippet)
+        assertEquals(article.thumbnailImage, imported.thumbnailImage)
+        assertEquals(article.enclosureLink, imported.enclosureLink)
+        assertEquals(article.enclosureType, imported.enclosureType)
+        assertEquals(article.author, imported.author)
+        assertEquals(article.link, imported.link)
+        assertEquals(ZonedDateTime.of(2026, 5, 12, 8, 30, 0, 0, ZoneOffset.UTC), imported.pubDate)
+        assertEquals(Instant.parse(article.primarySortTime), imported.primarySortTime)
+        assertEquals(Instant.parse(article.readTime!!), imported.readTime)
+        assertEquals(article.wordCount, imported.wordCount)
+        assertEquals(article.wordCountFull, imported.wordCountFull)
+        assertEquals(feedId, imported.feedId)
+    }
+
+    @SmallTest
+    @Test
+    fun testExportThenImportSavedArticlesRestoresMissingArticle() {
+        runBlocking {
+            val article = savedArticleExportItem()
+            val (itemId, feedId) = insertTestDataWithFeed()
+            db.feedItemDao().setBookmarked(itemId, true)
+
+            assertTrue {
+                exportSavedArticles(
+                    di,
+                    path!!.toUri(),
+                ).isRight()
+            }
+
+            db.feedItemDao().deleteFeedItems(listOf(itemId))
+            Assert.assertNull(db.feedItemDao().loadFeedItem(article.guid, feedId))
+
+            assertTrue {
+                importSavedArticles(
+                    di,
+                    path!!.toUri(),
+                ).isRight()
+            }
+
+            val imported = assertNotNull(db.feedItemDao().loadFeedItem(article.guid, feedId))
+            assertSavedArticleRestored(
+                article = article,
+                imported = imported,
                 feedId = feedId,
-                link = article.link,
-                pubDate = ZonedDateTime.of(2026, 5, 12, 8, 30, 0, 0, ZoneOffset.UTC),
-                primarySortTime = Instant.parse("2026-05-12T08:29:30Z"),
-                readTime = Instant.parse("2026-05-12T08:31:00Z"),
-                wordCount = article.wordCount,
-                wordCountFull = article.wordCountFull,
-            ),
-        )
+            )
+        }
     }
 
     @SmallTest
@@ -231,21 +294,12 @@ class ExportSavedTest : DIAware {
                 ).isRight()
             }
 
-            val imported = db.feedItemDao().loadFeedItem(article.guid, feedId)!!
-            assertTrue(imported.bookmarked)
-            assertEquals(article.title, imported.plainTitle)
-            assertEquals(article.snippet, imported.plainSnippet)
-            assertEquals(article.thumbnailImage, imported.thumbnailImage)
-            assertEquals(article.enclosureLink, imported.enclosureLink)
-            assertEquals(article.enclosureType, imported.enclosureType)
-            assertEquals(article.author, imported.author)
-            assertEquals(article.link, imported.link)
-            assertEquals(ZonedDateTime.of(2026, 5, 12, 8, 30, 0, 0, ZoneOffset.UTC), imported.pubDate)
-            assertEquals(Instant.parse(article.primarySortTime), imported.primarySortTime)
-            assertEquals(Instant.parse(article.readTime!!), imported.readTime)
-            assertEquals(article.wordCount, imported.wordCount)
-            assertEquals(article.wordCountFull, imported.wordCountFull)
-            assertEquals(feedId, imported.feedId)
+            val imported = assertNotNull(db.feedItemDao().loadFeedItem(article.guid, feedId))
+            assertSavedArticleRestored(
+                article = article,
+                imported = imported,
+                feedId = feedId,
+            )
         }
     }
 }

--- a/app/src/androidTest/java/com/nononsenseapps/feeder/model/export/ExportSavedTest.kt
+++ b/app/src/androidTest/java/com/nononsenseapps/feeder/model/export/ExportSavedTest.kt
@@ -132,4 +132,28 @@ class ExportSavedTest : DIAware {
             ),
         )
     }
+
+    @SmallTest
+    @Test
+    fun testImportSavedArticles() {
+        runBlocking {
+            val itemId = insertTestData()
+            path!!.writeText(
+                """
+                https://example.com/ampersands
+                https://example.com/not-in-db
+
+                https://example.com/ampersands
+                """.trimIndent(),
+            )
+            Assert.assertFalse(db.feedItemDao().loadFeedItem(itemId)!!.bookmarked)
+            assertTrue {
+                importSavedArticles(
+                    di,
+                    path!!.toUri(),
+                ).isRight()
+            }
+            assertTrue(db.feedItemDao().loadFeedItem(itemId)!!.bookmarked)
+        }
+    }
 }

--- a/app/src/androidTest/java/com/nononsenseapps/feeder/model/export/ExportSavedTest.kt
+++ b/app/src/androidTest/java/com/nononsenseapps/feeder/model/export/ExportSavedTest.kt
@@ -110,74 +110,74 @@ class ExportSavedTest : DIAware {
             assertEquals(SAVED_ARTICLES_EXPORT_FORMAT, result.format)
             assertEquals(SAVED_ARTICLES_EXPORT_VERSION, result.version)
             assertEquals(
-                listOf(
-                    SavedArticleExportItem(
-                        link = "https://example.com/ampersands/1",
-                        guid = "guid anime2you",
-                        title = "Item with image",
-                        snippet = "Snippet with image",
-                        pubDate = "2026-05-12T08:30Z",
-                        primarySortTime = "2026-05-12T08:29:30Z",
-                        readTime = "2026-05-12T08:31:00Z",
-                        author = "Example Author",
-                        thumbnailImage =
-                            MediaImage(
-                                url = "https://example.com/ampersands/image.png",
-                                width = 640,
-                                height = 320,
-                            ),
-                        enclosureLink = "https://example.com/ampersands/podcast.mp3",
-                        enclosureType = "audio/mpeg",
-                        wordCount = 42,
-                        wordCountFull = 420,
-                        feed =
-                            SavedArticleFeedExportItem(
-                                url = "https://example.com/ampersands",
-                                title = "Ampersands are & the worst",
-                                customTitle = "Ampersands",
-                                tag = "Characters",
-                                fullTextByDefault = true,
-                            ),
-                    ),
-                ),
+                listOf(savedArticleExportItem()),
                 result.articles,
             )
         }
     }
 
-    private suspend fun insertTestData(): Long {
-        val feedId =
-            db.feedDao().insertFeed(
-                Feed(
+    private fun savedArticleExportItem(): SavedArticleExportItem =
+        SavedArticleExportItem(
+            link = "https://example.com/ampersands/1",
+            guid = "guid anime2you",
+            title = "Item with image",
+            snippet = "Snippet with image",
+            pubDate = "2026-05-12T08:30Z",
+            primarySortTime = "2026-05-12T08:29:30Z",
+            readTime = "2026-05-12T08:31:00Z",
+            author = "Example Author",
+            thumbnailImage =
+                MediaImage(
+                    url = "https://example.com/ampersands/image.png",
+                    width = 640,
+                    height = 320,
+                ),
+            enclosureLink = "https://example.com/ampersands/podcast.mp3",
+            enclosureType = "audio/mpeg",
+            wordCount = 42,
+            wordCountFull = 420,
+            feed =
+                SavedArticleFeedExportItem(
+                    url = "https://example.com/ampersands",
                     title = "Ampersands are & the worst",
                     customTitle = "Ampersands",
-                    url = URL("https://example.com/ampersands"),
                     tag = "Characters",
                     fullTextByDefault = true,
                 ),
-            )
+        )
 
+    private suspend fun insertTestFeed(): Long {
+        val article = savedArticleExportItem()
+        return db.feedDao().insertFeed(
+            Feed(
+                title = article.feed.title,
+                customTitle = article.feed.customTitle,
+                url = URL(article.feed.url),
+                tag = article.feed.tag,
+                fullTextByDefault = article.feed.fullTextByDefault,
+            ),
+        )
+    }
+
+    private suspend fun insertTestData(): Long {
+        val article = savedArticleExportItem()
+        val feedId = insertTestFeed()
         return db.feedItemDao().insertFeedItem(
             FeedItem(
-                guid = "guid anime2you",
-                plainTitle = "Item with image",
-                plainSnippet = "Snippet with image",
-                thumbnailImage =
-                    MediaImage(
-                        url = "https://example.com/ampersands/image.png",
-                        width = 640,
-                        height = 320,
-                    ),
-                enclosureLink = "https://example.com/ampersands/podcast.mp3",
-                enclosureType = "audio/mpeg",
-                author = "Example Author",
+                guid = article.guid,
+                plainTitle = article.title,
+                plainSnippet = article.snippet,
+                thumbnailImage = article.thumbnailImage,
+                enclosureLink = article.enclosureLink,
+                enclosureType = article.enclosureType,
+                author = article.author,
                 feedId = feedId,
-                link = "https://example.com/ampersands/1",
+                link = article.link,
                 pubDate = ZonedDateTime.of(2026, 5, 12, 8, 30, 0, 0, ZoneOffset.UTC),
                 primarySortTime = Instant.parse("2026-05-12T08:29:30Z"),
                 readTime = Instant.parse("2026-05-12T08:31:00Z"),
-                wordCount = 42,
-                wordCountFull = 420,
+                wordCount = article.wordCount,
+                wordCountFull = article.wordCountFull,
             ),
         )
     }
@@ -189,10 +189,10 @@ class ExportSavedTest : DIAware {
             val itemId = insertTestData()
             path!!.writeText(
                 """
-                https://example.com/ampersands
+                https://example.com/ampersands/1
                 https://example.com/not-in-db
 
-                https://example.com/ampersands
+                https://example.com/ampersands/1
                 """.trimIndent(),
             )
             Assert.assertFalse(db.feedItemDao().loadFeedItem(itemId)!!.bookmarked)
@@ -203,6 +203,49 @@ class ExportSavedTest : DIAware {
                 ).isRight()
             }
             assertTrue(db.feedItemDao().loadFeedItem(itemId)!!.bookmarked)
+        }
+    }
+
+    @SmallTest
+    @Test
+    fun testImportSavedArticlesExportRestoresMissingArticle() {
+        runBlocking {
+            val article = savedArticleExportItem()
+            val feedId = insertTestFeed()
+            path!!.writeText(
+                Json.encodeToString(
+                    SavedArticlesExport.serializer(),
+                    SavedArticlesExport(
+                        format = SAVED_ARTICLES_EXPORT_FORMAT,
+                        version = SAVED_ARTICLES_EXPORT_VERSION,
+                        articles = listOf(article),
+                    ),
+                ),
+            )
+
+            Assert.assertNull(db.feedItemDao().loadFeedItem(article.guid, feedId))
+            assertTrue {
+                importSavedArticles(
+                    di,
+                    path!!.toUri(),
+                ).isRight()
+            }
+
+            val imported = db.feedItemDao().loadFeedItem(article.guid, feedId)!!
+            assertTrue(imported.bookmarked)
+            assertEquals(article.title, imported.plainTitle)
+            assertEquals(article.snippet, imported.plainSnippet)
+            assertEquals(article.thumbnailImage, imported.thumbnailImage)
+            assertEquals(article.enclosureLink, imported.enclosureLink)
+            assertEquals(article.enclosureType, imported.enclosureType)
+            assertEquals(article.author, imported.author)
+            assertEquals(article.link, imported.link)
+            assertEquals(ZonedDateTime.of(2026, 5, 12, 8, 30, 0, 0, ZoneOffset.UTC), imported.pubDate)
+            assertEquals(Instant.parse(article.primarySortTime), imported.primarySortTime)
+            assertEquals(Instant.parse(article.readTime!!), imported.readTime)
+            assertEquals(article.wordCount, imported.wordCount)
+            assertEquals(article.wordCountFull, imported.wordCountFull)
+            assertEquals(feedId, imported.feedId)
         }
     }
 }

--- a/app/src/androidTest/java/com/nononsenseapps/feeder/model/export/ExportSavedTest.kt
+++ b/app/src/androidTest/java/com/nononsenseapps/feeder/model/export/ExportSavedTest.kt
@@ -21,6 +21,7 @@ import com.nononsenseapps.feeder.model.OPMLParserHandler
 import com.nononsenseapps.feeder.model.opml.OPMLImporter
 import com.nononsenseapps.feeder.util.ToastMaker
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -103,10 +104,14 @@ class ExportSavedTest : DIAware {
                 ).isRight()
             }
 
-            val result = path!!.readLines()
+            val result = Json.decodeFromString(SavedArticlesExport.serializer(), path!!.readText())
 
-            assertEquals(1, result.size)
-            assertEquals("https://example.com/ampersands/1", result.first())
+            assertEquals(SAVED_ARTICLES_EXPORT_FORMAT, result.format)
+            assertEquals(SAVED_ARTICLES_EXPORT_VERSION, result.version)
+            assertEquals(
+                listOf(SavedArticleExportItem("https://example.com/ampersands/1")),
+                result.articles,
+            )
         }
     }
 

--- a/app/src/main/java/com/nononsenseapps/feeder/db/room/FeedItemDao.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/db/room/FeedItemDao.kt
@@ -79,6 +79,9 @@ interface FeedItemDao {
     @Query("SELECT * FROM feed_items WHERE id IS :id")
     suspend fun loadFeedItem(id: Long): FeedItem?
 
+    @Query("SELECT * FROM feed_items WHERE link IS :link ORDER BY id LIMIT 1")
+    suspend fun loadFeedItemByLink(link: String): FeedItem?
+
     @Query(
         """
         SELECT $FEED_ITEM_COLUMNS_WITH_FEED

--- a/app/src/main/java/com/nononsenseapps/feeder/db/room/FeedItemDao.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/db/room/FeedItemDao.kt
@@ -373,6 +373,18 @@ interface FeedItemDao {
     @Query("UPDATE feed_items SET bookmarked = 1 WHERE link IN (:links)")
     suspend fun setBookmarkedByLinks(links: List<String>): Int
 
+    @Query(
+        """
+        SELECT $FEED_ITEM_COLUMNS_WITH_FEED
+        FROM feed_items
+        LEFT JOIN feeds ON feed_items.feed_id = feeds.id
+        WHERE bookmarked = 1
+          AND link IS NOT NULL
+        ORDER BY link
+        """,
+    )
+    suspend fun getBookmarkedItemsForExport(): List<FeedItemWithFeed>
+
     @Query("SELECT link FROM feed_items WHERE bookmarked = 1 order by link")
     suspend fun getLinksOfBookmarks(): List<String>
 

--- a/app/src/main/java/com/nononsenseapps/feeder/db/room/FeedItemDao.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/db/room/FeedItemDao.kt
@@ -370,6 +370,9 @@ interface FeedItemDao {
         bookmarked: Boolean,
     )
 
+    @Query("UPDATE feed_items SET bookmarked = 1 WHERE link IN (:links)")
+    suspend fun setBookmarkedByLinks(links: List<String>): Int
+
     @Query("SELECT link FROM feed_items WHERE bookmarked = 1 order by link")
     suspend fun getLinksOfBookmarks(): List<String>
 

--- a/app/src/main/java/com/nononsenseapps/feeder/db/room/FeedItemWithFeed.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/db/room/FeedItemWithFeed.kt
@@ -18,6 +18,7 @@ import com.nononsenseapps.feeder.db.COL_IMAGEURL
 import com.nononsenseapps.feeder.db.COL_LINK
 import com.nononsenseapps.feeder.db.COL_PLAINSNIPPET
 import com.nononsenseapps.feeder.db.COL_PLAINTITLE
+import com.nononsenseapps.feeder.db.COL_PRIMARYSORTTIME
 import com.nononsenseapps.feeder.db.COL_PUBDATE
 import com.nononsenseapps.feeder.db.COL_READ_TIME
 import com.nononsenseapps.feeder.db.COL_TAG
@@ -44,6 +45,7 @@ const val FEED_ITEM_COLUMNS_WITH_FEED = """
     $FEEDS_TABLE_NAME.$COL_URL AS $COL_FEEDURL,
     $FEEDS_TABLE_NAME.$COL_FULLTEXT_BY_DEFAULT AS $COL_FULLTEXT_BY_DEFAULT,
     $COL_BOOKMARKED,
+    $COL_PRIMARYSORTTIME,
     $COL_WORD_COUNT,
     $COL_WORD_COUNT_FULL
 """
@@ -71,6 +73,7 @@ data class FeedItemWithFeed
         @ColumnInfo(name = COL_FEEDURL) var feedUrl: URL = sloppyLinkToStrictURLNoThrows(""),
         @ColumnInfo(name = COL_FULLTEXT_BY_DEFAULT) var fullTextByDefault: Boolean = false,
         @ColumnInfo(name = COL_BOOKMARKED) var bookmarked: Boolean = false,
+        @ColumnInfo(name = COL_PRIMARYSORTTIME) var primarySortTime: Instant = Instant.EPOCH,
         @ColumnInfo(name = COL_WORD_COUNT) var wordCount: Int = 0,
         @ColumnInfo(name = COL_WORD_COUNT_FULL) var wordCountFull: Int = 0,
     ) : FeedItemForFetching {

--- a/app/src/main/java/com/nononsenseapps/feeder/model/export/SavedArticlesExporter.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/export/SavedArticlesExporter.kt
@@ -10,12 +10,22 @@ import com.nononsenseapps.feeder.util.ToastMaker
 import com.nononsenseapps.feeder.util.logDebug
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.kodein.di.DI
 import org.kodein.di.direct
 import org.kodein.di.instance
 import kotlin.system.measureTimeMillis
 
 private const val LOG_TAG = "FEEDER_SAVEDARTEXPORT"
+const val SAVED_ARTICLES_EXPORT_FORMAT = "feeder-saved-articles"
+const val SAVED_ARTICLES_EXPORT_VERSION = 1
+
+private val savedArticlesJson =
+    Json {
+        prettyPrint = true
+    }
 
 suspend fun exportSavedArticles(
     di: DI,
@@ -39,17 +49,33 @@ suspend fun exportSavedArticles(
                     val contentResolver: ContentResolver by di.instance()
                     val feedItemDao: FeedItemDao by di.instance()
                     contentResolver.openOutputStream(uri)?.bufferedWriter()?.use { bw ->
-                        feedItemDao
-                            .getLinksOfBookmarks()
-                            .forEach { link ->
-                                bw.write(link)
-                                bw.newLine()
-                            }
+                        val export =
+                            SavedArticlesExport(
+                                format = SAVED_ARTICLES_EXPORT_FORMAT,
+                                version = SAVED_ARTICLES_EXPORT_VERSION,
+                                articles =
+                                    feedItemDao
+                                        .getLinksOfBookmarks()
+                                        .map(::SavedArticleExportItem),
+                            )
+                        bw.write(savedArticlesJson.encodeToString(export))
                     }
                 }
             logDebug(LOG_TAG, "Exported saved articles in $time ms on ${Thread.currentThread().name}")
         }
     }
+
+@Serializable
+data class SavedArticlesExport(
+    val format: String,
+    val version: Int,
+    val articles: List<SavedArticleExportItem>,
+)
+
+@Serializable
+data class SavedArticleExportItem(
+    val link: String,
+)
 
 sealed class SavedArticlesExportError {
     abstract val throwable: Throwable?

--- a/app/src/main/java/com/nononsenseapps/feeder/model/export/SavedArticlesExporter.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/export/SavedArticlesExporter.kt
@@ -5,6 +5,8 @@ import android.net.Uri
 import android.util.Log
 import com.nononsenseapps.feeder.R
 import com.nononsenseapps.feeder.db.room.FeedItemDao
+import com.nononsenseapps.feeder.db.room.FeedItemWithFeed
+import com.nononsenseapps.feeder.model.ThumbnailImage
 import com.nononsenseapps.feeder.util.Either
 import com.nononsenseapps.feeder.util.ToastMaker
 import com.nononsenseapps.feeder.util.logDebug
@@ -55,8 +57,8 @@ suspend fun exportSavedArticles(
                                 version = SAVED_ARTICLES_EXPORT_VERSION,
                                 articles =
                                     feedItemDao
-                                        .getLinksOfBookmarks()
-                                        .map(::SavedArticleExportItem),
+                                        .getBookmarkedItemsForExport()
+                                        .mapNotNull(FeedItemWithFeed::toSavedArticleExportItem),
                             )
                         bw.write(savedArticlesJson.encodeToString(export))
                     }
@@ -75,7 +77,56 @@ data class SavedArticlesExport(
 @Serializable
 data class SavedArticleExportItem(
     val link: String,
+    val guid: String,
+    val title: String,
+    val snippet: String,
+    val pubDate: String?,
+    val primarySortTime: String,
+    val readTime: String?,
+    val author: String?,
+    val thumbnailImage: ThumbnailImage?,
+    val enclosureLink: String?,
+    val enclosureType: String?,
+    val wordCount: Int,
+    val wordCountFull: Int,
+    val feed: SavedArticleFeedExportItem,
 )
+
+@Serializable
+data class SavedArticleFeedExportItem(
+    val url: String,
+    val title: String,
+    val customTitle: String,
+    val tag: String,
+    val fullTextByDefault: Boolean,
+)
+
+private fun FeedItemWithFeed.toSavedArticleExportItem(): SavedArticleExportItem? {
+    val articleLink = link ?: return null
+    return SavedArticleExportItem(
+        link = articleLink,
+        guid = guid,
+        title = plainTitle,
+        snippet = plainSnippet,
+        pubDate = pubDate?.toString(),
+        primarySortTime = primarySortTime.toString(),
+        readTime = readTime?.toString(),
+        author = author,
+        thumbnailImage = thumbnailImage,
+        enclosureLink = enclosureLink,
+        enclosureType = enclosureType,
+        wordCount = wordCount,
+        wordCountFull = wordCountFull,
+        feed =
+            SavedArticleFeedExportItem(
+                url = feedUrl.toString(),
+                title = feedTitle,
+                customTitle = feedCustomTitle,
+                tag = tag,
+                fullTextByDefault = fullTextByDefault,
+            ),
+    )
+}
 
 sealed class SavedArticlesExportError {
     abstract val throwable: Throwable?

--- a/app/src/main/java/com/nononsenseapps/feeder/model/export/SavedArticlesImporter.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/export/SavedArticlesImporter.kt
@@ -4,18 +4,30 @@ import android.content.ContentResolver
 import android.net.Uri
 import android.util.Log
 import com.nononsenseapps.feeder.R
+import com.nononsenseapps.feeder.db.room.Feed
+import com.nononsenseapps.feeder.db.room.FeedDao
+import com.nononsenseapps.feeder.db.room.FeedItem
 import com.nononsenseapps.feeder.db.room.FeedItemDao
 import com.nononsenseapps.feeder.util.Either
 import com.nononsenseapps.feeder.util.ToastMaker
 import com.nononsenseapps.feeder.util.logDebug
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
 import org.kodein.di.DI
 import org.kodein.di.direct
 import org.kodein.di.instance
+import java.net.URL
+import java.time.Instant
+import java.time.ZonedDateTime
 import kotlin.system.measureTimeMillis
 
 private const val LOG_TAG = "FEEDER_SAVEDARTIMPORT"
+
+private val savedArticlesImportJson =
+    Json {
+        ignoreUnknownKeys = true
+    }
 
 suspend fun importSavedArticles(
     di: DI,
@@ -38,21 +50,124 @@ suspend fun importSavedArticles(
                 measureTimeMillis {
                     val contentResolver: ContentResolver by di.instance()
                     val feedItemDao: FeedItemDao by di.instance()
-                    val links =
-                        contentResolver.openInputStream(uri)?.bufferedReader()?.useLines { lines ->
-                            lines
-                                .map { it.trim() }
-                                .filterNot { it.isBlank() }
-                                .distinct()
-                                .toList()
-                        } ?: emptyList()
+                    val feedDao: FeedDao by di.instance()
+                    val content =
+                        contentResolver.openInputStream(uri)?.bufferedReader()?.use { reader ->
+                            reader.readText()
+                        } ?: ""
 
-                    links.chunked(500).forEach { chunk ->
-                        feedItemDao.setBookmarkedByLinks(chunk)
+                    if (content.trimStart().startsWith("{")) {
+                        importSavedArticlesExport(
+                            feedDao = feedDao,
+                            feedItemDao = feedItemDao,
+                            export = savedArticlesImportJson.decodeFromString(SavedArticlesExport.serializer(), content),
+                        )
+                    } else {
+                        importLegacySavedArticleLinks(feedItemDao, content)
                     }
                 }
             logDebug(LOG_TAG, "Imported saved articles in $time ms on ${Thread.currentThread().name}")
         }
+    }
+
+private suspend fun importSavedArticlesExport(
+    feedDao: FeedDao,
+    feedItemDao: FeedItemDao,
+    export: SavedArticlesExport,
+) {
+    require(export.format == SAVED_ARTICLES_EXPORT_FORMAT) {
+        "Unsupported saved articles export format: ${export.format}"
+    }
+    require(export.version == SAVED_ARTICLES_EXPORT_VERSION) {
+        "Unsupported saved articles export version: ${export.version}"
+    }
+
+    export.articles.forEach { article ->
+        val feedId = feedDao.resolveFeedId(article.feed)
+        val existingItem =
+            feedId?.let { id ->
+                feedItemDao.loadFeedItem(
+                    guid = article.guid.ifBlank { article.link },
+                    feedId = id,
+                )
+            } ?: feedItemDao.loadFeedItemByLink(article.link)
+
+        if (existingItem != null) {
+            feedItemDao.setBookmarked(existingItem.id, true)
+        } else {
+            feedItemDao.insertFeedItem(article.toFeedItem(feedId))
+        }
+    }
+}
+
+private suspend fun importLegacySavedArticleLinks(
+    feedItemDao: FeedItemDao,
+    content: String,
+) {
+    val links =
+        content
+            .lineSequence()
+            .map { it.trim() }
+            .filterNot { it.isBlank() }
+            .distinct()
+            .toList()
+
+    links.chunked(500).forEach { chunk ->
+        feedItemDao.setBookmarkedByLinks(chunk)
+    }
+}
+
+private suspend fun FeedDao.resolveFeedId(feed: SavedArticleFeedExportItem): Long? {
+    val feedUrl = runCatching { URL(feed.url) }.getOrNull() ?: return null
+
+    return getFeedIdForUrl(feedUrl)
+        ?: insertFeed(
+            Feed(
+                title = feed.title,
+                customTitle = feed.customTitle,
+                url = feedUrl,
+                tag = feed.tag,
+                fullTextByDefault = feed.fullTextByDefault,
+            ),
+        )
+}
+
+private fun SavedArticleExportItem.toFeedItem(feedId: Long?): FeedItem {
+    val parsedPubDate = pubDate.parseZonedDateTimeOrNull()
+    val parsedPrimarySortTime =
+        primarySortTime.parseInstantOrNull()
+            ?: parsedPubDate?.toInstant()
+            ?: Instant.now()
+
+    return FeedItem(
+        guid = guid.ifBlank { link },
+        plainTitle = title,
+        plainSnippet = snippet,
+        thumbnailImage = thumbnailImage,
+        enclosureLink = enclosureLink,
+        enclosureType = enclosureType,
+        author = author,
+        pubDate = parsedPubDate,
+        link = link,
+        notified = true,
+        feedId = feedId,
+        firstSyncedTime = parsedPrimarySortTime,
+        primarySortTime = parsedPrimarySortTime,
+        bookmarked = true,
+        readTime = readTime.parseInstantOrNull(),
+        wordCount = wordCount,
+        wordCountFull = wordCountFull,
+    )
+}
+
+private fun String?.parseZonedDateTimeOrNull(): ZonedDateTime? =
+    this?.let { value ->
+        runCatching { ZonedDateTime.parse(value) }.getOrNull()
+    }
+
+private fun String?.parseInstantOrNull(): Instant? =
+    this?.let { value ->
+        runCatching { Instant.parse(value) }.getOrNull()
     }
 
 sealed class SavedArticlesImportError {

--- a/app/src/main/java/com/nononsenseapps/feeder/model/export/SavedArticlesImporter.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/export/SavedArticlesImporter.kt
@@ -1,0 +1,64 @@
+package com.nononsenseapps.feeder.model.export
+
+import android.content.ContentResolver
+import android.net.Uri
+import android.util.Log
+import com.nononsenseapps.feeder.R
+import com.nononsenseapps.feeder.db.room.FeedItemDao
+import com.nononsenseapps.feeder.util.Either
+import com.nononsenseapps.feeder.util.ToastMaker
+import com.nononsenseapps.feeder.util.logDebug
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.kodein.di.DI
+import org.kodein.di.direct
+import org.kodein.di.instance
+import kotlin.system.measureTimeMillis
+
+private const val LOG_TAG = "FEEDER_SAVEDARTIMPORT"
+
+suspend fun importSavedArticles(
+    di: DI,
+    uri: Uri,
+): Either<SavedArticlesImportError, Unit> =
+    Either.catching(
+        onCatch = {
+            Log.e(LOG_TAG, "Failed to import saved articles", it)
+            val toastMaker = di.direct.instance<ToastMaker>()
+            toastMaker.makeToast(R.string.failed_to_import_saved_articles)
+            (it.localizedMessage ?: it.message)?.let { message ->
+                toastMaker.makeToast(message)
+            }
+
+            SavedArticleImportUnknownError(it)
+        },
+    ) {
+        withContext(Dispatchers.IO) {
+            val time =
+                measureTimeMillis {
+                    val contentResolver: ContentResolver by di.instance()
+                    val feedItemDao: FeedItemDao by di.instance()
+                    val links =
+                        contentResolver.openInputStream(uri)?.bufferedReader()?.useLines { lines ->
+                            lines
+                                .map { it.trim() }
+                                .filterNot { it.isBlank() }
+                                .distinct()
+                                .toList()
+                        } ?: emptyList()
+
+                    links.chunked(500).forEach { chunk ->
+                        feedItemDao.setBookmarkedByLinks(chunk)
+                    }
+                }
+            logDebug(LOG_TAG, "Imported saved articles in $time ms on ${Thread.currentThread().name}")
+        }
+    }
+
+sealed class SavedArticlesImportError {
+    abstract val throwable: Throwable?
+}
+
+data class SavedArticleImportUnknownError(
+    override val throwable: Throwable,
+) : SavedArticlesImportError()

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
@@ -182,7 +182,7 @@ fun FeedScreen(
     val di = LocalDI.current
     val savedArticleExporter =
         rememberLauncherForActivityResult(
-            ActivityResultContracts.CreateDocument("text/plain"),
+            ActivityResultContracts.CreateDocument("application/json"),
         ) { uri ->
             if (uri != null) {
                 val applicationCoroutineScope: ApplicationCoroutineScope by di.instance()
@@ -387,7 +387,7 @@ fun FeedScreen(
                     savedArticleExporter.launch(
                         "feeder-saved-articles-${LocalDate.now()}-${
                             LocalTime.now().toSecondOfDay()
-                        }.txt",
+                        }.json",
                     )
                 } catch (_: Exception) {
                     // ActivityNotFoundException in particular

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
@@ -116,6 +116,7 @@ import com.nononsenseapps.feeder.db.room.ID_SAVED_ARTICLES
 import com.nononsenseapps.feeder.db.room.ID_UNSET
 import com.nononsenseapps.feeder.model.LocaleOverride
 import com.nononsenseapps.feeder.model.export.exportSavedArticles
+import com.nononsenseapps.feeder.model.export.importSavedArticles
 import com.nononsenseapps.feeder.model.opml.exportOpml
 import com.nononsenseapps.feeder.model.opml.importOpml
 import com.nononsenseapps.feeder.ui.compose.components.safeSemantics
@@ -181,7 +182,7 @@ fun FeedScreen(
     val di = LocalDI.current
     val savedArticleExporter =
         rememberLauncherForActivityResult(
-            ActivityResultContracts.CreateDocument("text/x-opml"),
+            ActivityResultContracts.CreateDocument("text/plain"),
         ) { uri ->
             if (uri != null) {
                 val applicationCoroutineScope: ApplicationCoroutineScope by di.instance()
@@ -209,6 +210,17 @@ fun FeedScreen(
                 val applicationCoroutineScope: ApplicationCoroutineScope by di.instance()
                 applicationCoroutineScope.launch {
                     importOpml(di, uri)
+                }
+            }
+        }
+    val savedArticleImporter =
+        rememberLauncherForActivityResult(
+            ActivityResultContracts.OpenDocument(),
+        ) { uri ->
+            if (uri != null) {
+                val applicationCoroutineScope: ApplicationCoroutineScope by di.instance()
+                applicationCoroutineScope.launch {
+                    importSavedArticles(di, uri)
                 }
             }
         }
@@ -352,6 +364,24 @@ fun FeedScreen(
                     }
                 }
             },
+            onImportSavedArticles = {
+                try {
+                    savedArticleImporter.launch(
+                        arrayOf(
+                            "text/plain",
+                            // This is the mimetype the file may get from older exports
+                            "application/octet-stream",
+                            // But just in case a file isn't named right etc, accept all
+                            "*/*",
+                        ),
+                    )
+                } catch (_: Exception) {
+                    // ActivityNotFoundException in particular
+                    coroutineScope.launch {
+                        toastMaker.makeToast(R.string.failed_to_import_saved_articles)
+                    }
+                }
+            },
             onExportSavedArticles = {
                 try {
                     savedArticleExporter.launch(
@@ -488,6 +518,7 @@ fun FeedScreen(
     onSettings: () -> Unit,
     onImport: () -> Unit,
     onExportOPML: () -> Unit,
+    onImportSavedArticles: () -> Unit,
     onExportSavedArticles: () -> Unit,
     drawerState: DrawerState,
     markAsUnread: (Long, Boolean) -> Unit,
@@ -878,6 +909,21 @@ fun FeedScreen(
                                 },
                                 text = {
                                     Text(stringResource(id = R.string.export_feeds_to_opml))
+                                },
+                            )
+                            DropdownMenuItem(
+                                onClick = {
+                                    onShowToolbarMenu(false)
+                                    onImportSavedArticles()
+                                },
+                                leadingIcon = {
+                                    Icon(
+                                        Icons.Default.ImportExport,
+                                        contentDescription = null,
+                                    )
+                                },
+                                text = {
+                                    Text(stringResource(id = R.string.import_saved_articles))
                                 },
                             )
                             DropdownMenuItem(

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
@@ -342,6 +342,7 @@ fun FeedScreen(
                             "text/x-opml",
                             "application/xml",
                             // This is the mimetype the file actually gets when exported
+                            "application/json",
                             "application/octet-stream",
                             // But just in case a file isn't named right etc, accept all
                             "*/*",

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,6 +48,7 @@
   <string name="export_feeds_to_opml">Export feeds to OPML</string>
   <string name="import_feeds_from_opml">Import feeds from OPML</string>
   <string name="export_saved_articles">Export saved articles</string>
+  <string name="import_saved_articles">Import saved articles</string>
   <string name="view_debug_log">View debug log</string>
   <string name="new_based_on_this">New based on this</string>
   <string name="indicator_for_mark_as_read">Indicator for mark as read</string>
@@ -174,6 +175,7 @@
   <string name="failed_to_import_OPML">"Failed to import OPML"</string>
   <string name="failed_to_export_OPML">"Failed to export OPML"</string>
   <string name="failed_to_export_saved_articles">"Failed to export saved articles"</string>
+  <string name="failed_to_import_saved_articles">"Failed to import saved articles"</string>
   <string name="device_sync">Device sync</string>
   <string name="add_new_device">Add new device</string>
   <string name="device_sync_financed_by_community">This service is paid for by the community. Please consider donating if you find it useful.</string>


### PR DESCRIPTION
Similarly to the user who created issue #913, I have noticed that Feeder is not able to import saved articles, which is a bit annoying when you switch devices. This PR should fix it. I have build this in Android Studio and tested it in a Google Pixel 9a emulator, and it seems to work.

Fixes #913 