### PR TITLE
feat: enabled arm memory tagging extension

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,6 +45,7 @@
     android:roundIcon="@mipmap/ic_launcher_round"
     android:supportsRtl="true"
     android:theme="@style/AppThemeDayNoActionBar"
+    android:memtagMode="async"
     android:usesCleartextTraffic="true">
 
     <meta-data


### PR DESCRIPTION
makes app exploitation much harder on devices and OS's with MTE support https://source.android.com/docs/security/test/memory-safety/arm-mte#enable-mte-apps

I was using Feeder for around a week and it runs fine for me on GrapheneOS with Memory tagging enabled for an app. Propose to enable it by default.

This change will affect:
- Google Pixel's users with stock OS with Advanced Protection enabled
- Google Pixel's users with GrapheneOS
- Samsung Galaxy users [in some near future](https://www.androidauthority.com/one-ui-9-memory-tagging-extension-spotted-3654992/)
- other devices with other OS's in some not that near future