### PR TITLE
fix: widget stuck in loading

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -49,6 +49,9 @@
 # Charset detection
 -keep class com.ibm.icu.** { *; }
 
+# For WorkManager - InputMerger subclasses are instantiated by name via reflection
+-keep class * extends androidx.work.InputMerger { <init>(); }
+
 # For Kodein
 -keep, allowobfuscation, allowoptimization class org.kodein.type.TypeReference
 -keep, allowobfuscation, allowoptimization class org.kodein.type.JVMAbstractTypeToken$Companion$WrappingTest


### PR DESCRIPTION
Okay wow, thanks for your patience while I figured this one out. I finally thought to try a local release build and was able to replicate the issue, which meant I could log what was happening. It would appear that R8 is minifying a work manager no-arg constructor used by Glance under the hood, and that's crashing on newer Android versions. Hopefully this is solved upstream at some point, but this seems to do it for now!

fixes #1113 