### PR TITLE
fix: corrected three sync read-status bugs

### DIFF
--- a/app/src/androidTest/java/com/nononsenseapps/feeder/model/RssLocalSyncKtTest.kt
+++ b/app/src/androidTest/java/com/nononsenseapps/feeder/model/RssLocalSyncKtTest.kt
@@ -21,7 +21,9 @@ import com.nononsenseapps.feeder.db.room.FeedDao
 import com.nononsenseapps.feeder.db.room.FeedItemDao
 import com.nononsenseapps.feeder.db.room.ID_UNSET
 import com.nononsenseapps.feeder.db.room.ReadStatusSyncedDao
+import com.nononsenseapps.feeder.db.room.RemoteReadMark
 import com.nononsenseapps.feeder.db.room.RemoteReadMarkDao
+import com.nononsenseapps.feeder.db.room.SyncRemote
 import com.nononsenseapps.feeder.db.room.SyncRemoteDao
 import com.nononsenseapps.feeder.di.networkModule
 import com.nononsenseapps.feeder.model.Feeds.Companion.RSS_WITH_DUPLICATE_GUIDS
@@ -825,6 +827,91 @@ class RssLocalSyncKtTest : DIAware {
             // Verify the selected article is still in the database
             val selectedArticleFromDb = testDb.db.feedItemDao().loadFeedItem(selectedArticleId)
             assertNotNull("Selected article should still exist in database", selectedArticleFromDb)
+        }
+
+    @Test
+    fun remoteReadMarkIsAppliedToNewItemAndMarkedAsSynced() =
+        runBlocking {
+            val feedUrl = server.url("/feed.json").toUrl()
+            val feedId = insertFeed("cowboyjson", feedUrl, cowboyJson)
+
+            val itemGuid = "https://cowboyprogrammer.org/2018/03/fixed-vs-variable-interest-rates/"
+
+            // SyncRemote must exist as FK parent for RemoteReadMark
+            testDb.db.syncRemoteDao().insert(SyncRemote(id = 1L, deviceName = "TestDevice", secretKey = ""))
+            testDb.db.remoteReadMarkDao().insert(
+                RemoteReadMark(
+                    sync_remote = 1L,
+                    feedUrl = feedUrl,
+                    guid = itemGuid,
+                    timestamp = Instant.now(),
+                ),
+            )
+
+            rssLocalSync.syncFeeds(feedId = feedId)
+
+            val feedItems = testDb.db.feedItemDao().loadFeedItemsInFeedDescDoNotUseInProd(feedId)
+            val item = feedItems.find { it.guid == itemGuid }
+            assertNotNull("Item should have been fetched from feed", item)
+            assertNotNull("Item should be marked as read via remote read-mark", item!!.readTime)
+
+            // With the fix: item must be in read_status_synced so it is not re-sent to server
+            val unsyncedReadItems = testDb.db.readStatusSyncedDao().getFeedItemsWithoutSyncedReadMark()
+            assertTrue(
+                "Item applied via remote read-mark must not appear as unsynced (would cause read echo back to server)",
+                unsyncedReadItems.none { it.id == item.id },
+            )
+        }
+
+    @Test
+    fun applyRemoteReadMarksCleansStaleEntriesForAlreadyReadItems() =
+        runBlocking {
+            val feedUrl = server.url("/feed.json").toUrl()
+            val feedId = insertFeed("cowboyjson", feedUrl, cowboyJson)
+
+            val itemGuid = "https://cowboyprogrammer.org/2018/03/fixed-vs-variable-interest-rates/"
+
+            testDb.db.syncRemoteDao().insert(SyncRemote(id = 1L, deviceName = "TestDevice", secretKey = ""))
+            testDb.db.remoteReadMarkDao().insert(
+                RemoteReadMark(
+                    sync_remote = 1L,
+                    feedUrl = feedUrl,
+                    guid = itemGuid,
+                    timestamp = Instant.now(),
+                ),
+            )
+
+            // First sync: item is fetched and marked as read via alreadyReadGuids
+            rssLocalSync.syncFeeds(feedId = feedId)
+
+            // Verify the mark still exists after syncFeeds (it was applied but not yet cleaned by applyRemoteReadMarks above)
+            // Now call applyRemoteReadMarks explicitly — this should clean up the stale entry
+            val repository: Repository by instance()
+            repository.applyRemoteReadMarks()
+
+            val remainingGuids = testDb.db.remoteReadMarkDao().getGuidsWhichAreSyncedAsReadInFeed(feedUrl)
+            assertTrue(
+                "Stale remote_read_mark entry should be cleaned up after applyRemoteReadMarks for already-read item",
+                remainingGuids.isEmpty(),
+            )
+        }
+
+    @Test
+    fun itemsNotInRemoteReadMarkAreNotMarkedAsRead() =
+        runBlocking {
+            val feedUrl = server.url("/feed.json").toUrl()
+            val feedId = insertFeed("cowboyjson", feedUrl, cowboyJson)
+
+            // No remote read marks inserted
+
+            rssLocalSync.syncFeeds(feedId = feedId)
+
+            val feedItems = testDb.db.feedItemDao().loadFeedItemsInFeedDescDoNotUseInProd(feedId)
+            assertEquals("Feed should have 10 items", 10, feedItems.size)
+            assertTrue(
+                "No items should be marked as read when there are no remote read marks",
+                feedItems.all { it.readTime == null },
+            )
         }
 
     private fun fooRss(itemsCount: Int = 1): String {

--- a/app/src/androidTest/java/com/nononsenseapps/feeder/sync/SyncRestClientTest.kt
+++ b/app/src/androidTest/java/com/nononsenseapps/feeder/sync/SyncRestClientTest.kt
@@ -1,0 +1,314 @@
+package com.nononsenseapps.feeder.sync
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.MediumTest
+import com.nononsenseapps.feeder.ApplicationCoroutineScope
+import com.nononsenseapps.feeder.FeederApplication
+import com.nononsenseapps.feeder.archmodel.AndroidSystemStore
+import com.nononsenseapps.feeder.archmodel.FeedItemStore
+import com.nononsenseapps.feeder.archmodel.FeedStore
+import com.nononsenseapps.feeder.archmodel.FontStore
+import com.nononsenseapps.feeder.archmodel.Repository
+import com.nononsenseapps.feeder.archmodel.SessionStore
+import com.nononsenseapps.feeder.archmodel.SettingsStore
+import com.nononsenseapps.feeder.archmodel.SyncRemoteStore
+import com.nononsenseapps.feeder.crypto.AesCbcWithIntegrity
+import com.nononsenseapps.feeder.crypto.SecretKeys
+import com.nononsenseapps.feeder.db.room.AppDatabase
+import com.nononsenseapps.feeder.db.room.BlocklistDao
+import com.nononsenseapps.feeder.db.room.Feed
+import com.nononsenseapps.feeder.db.room.FeedDao
+import com.nononsenseapps.feeder.db.room.FeedItem
+import com.nononsenseapps.feeder.db.room.FeedItemDao
+import com.nononsenseapps.feeder.db.room.ReadStatusSyncedDao
+import com.nononsenseapps.feeder.db.room.RemoteReadMarkDao
+import com.nononsenseapps.feeder.db.room.SyncRemote
+import com.nononsenseapps.feeder.db.room.SyncRemoteDao
+import com.nononsenseapps.feeder.di.networkModule
+import com.nononsenseapps.feeder.ui.TestDatabaseRule
+import com.nononsenseapps.feeder.util.FilePathProvider
+import com.nononsenseapps.feeder.util.filePathProvider
+import com.nononsenseapps.jsonfeed.cachingHttpClient
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.kodein.di.DI
+import org.kodein.di.DIAware
+import org.kodein.di.bind
+import org.kodein.di.instance
+import org.kodein.di.singleton
+import java.net.URL
+import java.time.Instant
+
+@RunWith(AndroidJUnit4::class)
+@MediumTest
+class SyncRestClientTest : DIAware {
+    @get:Rule
+    val testDb = TestDatabaseRule(getApplicationContext())
+
+    override val di by DI.lazy {
+        bind<AppDatabase>() with instance(testDb.db)
+        bind<FeedDao>() with singleton { testDb.db.feedDao() }
+        bind<FeedItemDao>() with singleton { testDb.db.feedItemDao() }
+        bind<BlocklistDao>() with singleton { testDb.db.blocklistDao() }
+        bind<RemoteReadMarkDao>() with singleton { testDb.db.remoteReadMarkDao() }
+        bind<ReadStatusSyncedDao>() with singleton { testDb.db.readStatusSyncedDao() }
+        bind<SyncRemoteDao>() with singleton { testDb.db.syncRemoteDao() }
+        bind<FeedStore>() with singleton { FeedStore(di) }
+        bind<FeedItemStore>() with singleton { FeedItemStore(di) }
+        bind<SettingsStore>() with
+            singleton {
+                SettingsStore(di).also { it.setAddedFeederNews(true) }
+            }
+        bind<FontStore>() with singleton { FontStore(di) }
+        bind<SessionStore>() with singleton { SessionStore() }
+        bind<SyncRemoteStore>() with singleton { SyncRemoteStore(di) }
+        bind<OkHttpClient>() with singleton { cachingHttpClient() }
+        import(networkModule)
+        bind<SharedPreferences>() with
+            singleton {
+                getApplicationContext<FeederApplication>().getSharedPreferences("synctest", Context.MODE_PRIVATE)
+            }
+        bind<ApplicationCoroutineScope>() with singleton { ApplicationCoroutineScope() }
+        bind<Repository>() with singleton { Repository(di) }
+        bind<FilePathProvider>() with
+            singleton {
+                filePathProvider(
+                    cacheDir = getApplicationContext<FeederApplication>().cacheDir,
+                    filesDir = getApplicationContext<FeederApplication>().filesDir,
+                )
+            }
+        bind<AndroidSystemStore>() with singleton { AndroidSystemStore(di) }
+    }
+
+    private val server = MockWebServer()
+
+    @After
+    fun stopServer() {
+        server.shutdown()
+    }
+
+    @Before
+    fun setup() {
+        server.start()
+    }
+
+    /**
+     * Creates a [SyncRestClient] wired to the [MockWebServer].
+     *
+     * A [SyncRemote] with a valid 64-char [SyncRemote.syncChainId] is inserted into the test
+     * database so that [SyncRestClient.safeBlock] passes its [SyncRemote.hasSyncChain] guard.
+     * [SyncRestClient.initForTesting] is then called to replace the HTTP client and key with
+     * instances that point directly at [server], ensuring no real network traffic occurs.
+     *
+     * Returns a [Triple] of the configured client, the raw [SecretKeys], and the [SyncRemote]
+     * that was stored in the database.
+     */
+    private suspend fun buildSyncRestClientWithMockServer(): Triple<SyncRestClient, SecretKeys, SyncRemote> {
+        val secretKey = AesCbcWithIntegrity.generateKey()
+        val syncRemote =
+            SyncRemote(
+                id = 1L,
+                syncChainId = "a".repeat(64),
+                secretKey = AesCbcWithIntegrity.encodeKey(secretKey),
+                url = server.url("/").toUrl(),
+            )
+        testDb.db.syncRemoteDao().insert(syncRemote)
+
+        // SyncRestClient.init{} calls initialize() which will find the SyncRemote we just
+        // inserted and configure itself.  We then call initForTesting to guarantee our
+        // test-local FeederSync instance (pointing at the MockWebServer) and key are used.
+        val syncRestClient = SyncRestClient(di)
+        val feederSync = getFeederSyncClient(syncRemote, cachingHttpClient())
+        syncRestClient.initForTesting(feederSync, secretKey)
+
+        return Triple(syncRestClient, secretKey, syncRemote)
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Test 1
+    // -----------------------------------------------------------------------------------------
+
+    /**
+     * When the server returns two encrypted read-marks, [SyncRestClient.getRead] should decrypt
+     * each one and insert the corresponding guids into the `remote_read_mark` table.
+     */
+    @Test
+    fun getReadCallsRemoteMarkAsReadForEachReceivedMark() =
+        runBlocking {
+            val (syncRestClient, secretKey, _) = buildSyncRestClientWithMockServer()
+
+            val moshi = getMoshi()
+            val readMarkAdapter = moshi.adapter<ReadMarkContent>()
+
+            val mark1 = ReadMarkContent(feedUrl = URL("https://example.com/feed"), articleGuid = "guid-1")
+            val mark2 = ReadMarkContent(feedUrl = URL("https://example.com/feed"), articleGuid = "guid-2")
+
+            val enc1 = AesCbcWithIntegrity.encryptString(readMarkAdapter.toJson(mark1), secretKey)
+            val enc2 = AesCbcWithIntegrity.encryptString(readMarkAdapter.toJson(mark2), secretKey)
+
+            val t1 = Instant.ofEpochMilli(1_704_067_200_000L) // 2024-01-01T00:00:00Z
+            val t2 = Instant.ofEpochMilli(1_704_153_600_000L) // 2024-01-02T00:00:00Z
+
+            val responseBody =
+                moshi.adapter<GetEncryptedReadMarksResponse>().toJson(
+                    GetEncryptedReadMarksResponse(
+                        readMarks =
+                            listOf(
+                                EncryptedReadMark(timestamp = t1, encrypted = enc1),
+                                EncryptedReadMark(timestamp = t2, encrypted = enc2),
+                            ),
+                    ),
+                )
+
+            server.enqueue(
+                MockResponse()
+                    .setBody(responseBody)
+                    .setResponseCode(200)
+                    .addHeader("Content-Type", "application/json"),
+            )
+
+            syncRestClient.getRead()
+
+            val guids =
+                testDb.db
+                    .remoteReadMarkDao()
+                    .getGuidsWhichAreSyncedAsReadInFeed(URL("https://example.com/feed"))
+
+            assertTrue("guid-1 should be in remote_read_mark", "guid-1" in guids)
+            assertTrue("guid-2 should be in remote_read_mark", "guid-2" in guids)
+        }
+
+    // -----------------------------------------------------------------------------------------
+    // Test 2
+    // -----------------------------------------------------------------------------------------
+
+    /**
+     * When the server returns a corrupt mark followed by a valid mark, [SyncRestClient.getRead]
+     * should advance [SyncRemote.latestMessageTimestamp] past both — including past the corrupt
+     * one — so the same mark is not retried on the next sync.
+     *
+     * The "corrupt" mark is produced by encrypting the JSON literal `"null"` with the correct
+     * key.  After decryption Moshi returns `null` for the `ReadMarkContent` adapter, which
+     * triggers the null-check fix in [SyncRestClient.getRead] that advances the timestamp and
+     * continues to the next mark.
+     */
+    @Test
+    fun getReadAdvancesTimestampPastCorruptMark() =
+        runBlocking {
+            val (syncRestClient, secretKey, _) = buildSyncRestClientWithMockServer()
+
+            val moshi = getMoshi()
+
+            // Encrypting the JSON literal "null" causes the Moshi adapter to return null
+            // (instead of throwing), which exercises the fix that still advances the timestamp.
+            val corruptEnc = AesCbcWithIntegrity.encryptString("null", secretKey)
+
+            val validContent =
+                ReadMarkContent(feedUrl = URL("https://example.com/feed"), articleGuid = "guid-valid")
+            val validEnc =
+                AesCbcWithIntegrity.encryptString(
+                    moshi.adapter<ReadMarkContent>().toJson(validContent),
+                    secretKey,
+                )
+
+            val t1 = Instant.ofEpochMilli(1_704_067_200_000L) // 2024-01-01T00:00:00Z
+            val t2 = Instant.ofEpochMilli(1_704_153_600_000L) // 2024-01-02T00:00:00Z
+
+            val responseBody =
+                moshi.adapter<GetEncryptedReadMarksResponse>().toJson(
+                    GetEncryptedReadMarksResponse(
+                        readMarks =
+                            listOf(
+                                EncryptedReadMark(timestamp = t1, encrypted = corruptEnc),
+                                EncryptedReadMark(timestamp = t2, encrypted = validEnc),
+                            ),
+                    ),
+                )
+
+            server.enqueue(
+                MockResponse()
+                    .setBody(responseBody)
+                    .setResponseCode(200)
+                    .addHeader("Content-Type", "application/json"),
+            )
+
+            syncRestClient.getRead()
+
+            val latestTimestamp =
+                testDb.db
+                    .syncRemoteDao()
+                    .getSyncRemote()!!
+                    .latestMessageTimestamp
+            assertEquals(
+                "latestMessageTimestamp should advance past the corrupt mark to t2",
+                t2,
+                latestTimestamp,
+            )
+        }
+
+    // -----------------------------------------------------------------------------------------
+    // Test 3
+    // -----------------------------------------------------------------------------------------
+
+    /**
+     * Given two feed items with a non-null [FeedItem.readTime] that have not yet been synced,
+     * [SyncRestClient.markAsRead] should POST them to the server and then record each item in
+     * `read_status_synced` so that they are no longer returned by
+     * [ReadStatusSyncedDao.getFeedItemsWithoutSyncedReadMark].
+     */
+    @Test
+    fun markAsReadSendsItemsAndMarksThemAsSynced() =
+        runBlocking {
+            val (syncRestClient, _, _) = buildSyncRestClientWithMockServer()
+
+            val feedId =
+                testDb.db.feedDao().insertFeed(
+                    Feed(title = "Test Feed", url = URL("https://example.com/feed")),
+                )
+            testDb.db.feedItemDao().insertFeedItem(
+                FeedItem(feedId = feedId, guid = "guid-1", readTime = Instant.now()),
+            )
+            testDb.db.feedItemDao().insertFeedItem(
+                FeedItem(feedId = feedId, guid = "guid-2", readTime = Instant.now()),
+            )
+
+            val t = Instant.ofEpochMilli(1_704_067_200_000L)
+            val responseBody =
+                getMoshi().adapter<SendReadMarkResponse>().toJson(SendReadMarkResponse(timestamp = t))
+
+            server.enqueue(
+                MockResponse()
+                    .setBody(responseBody)
+                    .setResponseCode(200)
+                    .addHeader("Content-Type", "application/json"),
+            )
+
+            syncRestClient.markAsRead()
+
+            val unsyncedItems =
+                testDb.db.readStatusSyncedDao().getFeedItemsWithoutSyncedReadMark()
+            assertTrue(
+                "All read items should be recorded in read_status_synced after markAsRead()",
+                unsyncedItems.isEmpty(),
+            )
+
+            val request = server.takeRequest()
+            assertEquals("Expected a POST request", "POST", request.method)
+            assertTrue(
+                "Request path should contain 'ereadmark'",
+                request.path?.contains("ereadmark") == true,
+            )
+        }
+}

--- a/app/src/main/java/com/nononsenseapps/feeder/archmodel/Repository.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/archmodel/Repository.kt
@@ -720,6 +720,9 @@ class Repository(
             syncRemoteStore.setSynced(itemId)
         }
         syncRemoteStore.deleteReadStatusSyncs(toBeApplied.map { it.id })
+        // Remove stale marks for items that are already read so they don't override a
+        // deliberate "mark as unread" on the next sync.
+        syncRemoteStore.deleteRemoteReadMarksForReadItems()
     }
 
     suspend fun replaceWithDefaultSyncRemote() {

--- a/app/src/main/java/com/nononsenseapps/feeder/archmodel/SyncRemoteStore.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/archmodel/SyncRemoteStore.kt
@@ -97,6 +97,10 @@ class SyncRemoteStore(
         remoteReadMarkDao.deleteStaleRemoteReadMarks(now.minus(7, ChronoUnit.DAYS))
     }
 
+    suspend fun deleteRemoteReadMarksForReadItems() {
+        remoteReadMarkDao.deleteRemoteReadMarksForReadItems()
+    }
+
     suspend fun getRemoteReadMarksReadyToBeApplied() = remoteReadMarkDao.getRemoteReadMarksReadyToBeApplied()
 
     suspend fun getGuidsWhichAreSyncedAsReadInFeed(feedUrl: URL) = remoteReadMarkDao.getGuidsWhichAreSyncedAsReadInFeed(feedUrl = feedUrl)

--- a/app/src/main/java/com/nononsenseapps/feeder/db/room/RemoteReadMarkDao.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/db/room/RemoteReadMarkDao.kt
@@ -27,6 +27,24 @@ interface RemoteReadMarkDao {
     )
     suspend fun deleteStaleRemoteReadMarks(oldestTimestamp: Instant): Int
 
+    /**
+     * Deletes remote read marks for items that have already been marked as read locally.
+     * This prevents stale marks from re-applying a read status after the user has
+     * explicitly marked an item as unread.
+     */
+    @Query(
+        """
+            DELETE FROM remote_read_mark
+            WHERE id IN (
+                SELECT rrm.id FROM remote_read_mark rrm
+                INNER JOIN feed_items fi ON rrm.guid = fi.guid
+                INNER JOIN feeds f ON f.id = fi.feed_id
+                WHERE f.url IS rrm.feed_url AND fi.read_time IS NOT NULL
+            )
+        """,
+    )
+    suspend fun deleteRemoteReadMarksForReadItems(): Int
+
     @Query(
         """
             SELECT remote_read_mark.id as id, fi.id as feed_item_id

--- a/app/src/main/java/com/nononsenseapps/feeder/model/RssLocalSync.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/RssLocalSync.kt
@@ -366,6 +366,11 @@ class RssLocalSync(
                             .use {
                                 it.write(text)
                             }
+                        // If this item was pre-marked as read from a remote read-mark (alreadyReadGuids),
+                        // immediately set it as synced so it won't be echoed back to the server.
+                        if (feedItem.guid in alreadyReadGuids) {
+                            repository.setSynced(feedItem.id)
+                        }
                     }
                     // Try to look for image if not done before
                     if (feedSql.imageUrl == null && feedSql.siteFetched == Instant.EPOCH) {

--- a/app/src/main/java/com/nononsenseapps/feeder/sync/SyncRestClient.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/sync/SyncRestClient.kt
@@ -1,6 +1,7 @@
 package com.nononsenseapps.feeder.sync
 
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import com.nononsenseapps.feeder.archmodel.Repository
 import com.nononsenseapps.feeder.crypto.AesCbcWithIntegrity
 import com.nononsenseapps.feeder.crypto.SecretKeys
@@ -396,6 +397,8 @@ class SyncRestClient(
 
                             if (readMarkContent == null) {
                                 Log.e(LOG_TAG, "Failed to decrypt readMark content")
+                                // Advance the timestamp so the same corrupt mark is not retried indefinitely.
+                                repository.updateSyncRemoteMessageTimestamp(readMark.timestamp)
                                 continue
                             }
 
@@ -608,6 +611,19 @@ class SyncRestClient(
             // this device has been removed from the chain from another device
             leave()
         }
+    }
+
+    /**
+     * Test-only helper that bypasses the normal [initialize] flow and directly sets the
+     * underlying [FeederSync] client and encryption key.
+     */
+    @VisibleForTesting
+    internal fun initForTesting(
+        feederSync: FeederSync,
+        secretKey: SecretKeys,
+    ) {
+        this.feederSync = feederSync
+        this.secretKey = secretKey
     }
 
     companion object {

--- a/app/src/test/java/com/nononsenseapps/feeder/archmodel/RepositoryTest.kt
+++ b/app/src/test/java/com/nononsenseapps/feeder/archmodel/RepositoryTest.kt
@@ -428,6 +428,24 @@ class RepositoryTest : DIAware {
             syncRemoteStore.setSynced(2L)
             syncRemoteStore.setSynced(4L)
             syncRemoteStore.deleteReadStatusSyncs(listOf(1L, 3L))
+            syncRemoteStore.deleteRemoteReadMarksForReadItems()
+        }
+        confirmVerified(feedItemStore, syncRemoteStore)
+    }
+
+    @Test
+    fun applyRemoteReadMarksCleansUpStaleMarksEvenWhenNothingToApply() {
+        coEvery { syncRemoteStore.getRemoteReadMarksReadyToBeApplied() } returns emptyList()
+
+        runBlocking {
+            repository.applyRemoteReadMarks()
+        }
+
+        coVerify {
+            syncRemoteStore.getRemoteReadMarksReadyToBeApplied()
+            feedItemStore.markAsRead(emptyList())
+            syncRemoteStore.deleteReadStatusSyncs(emptyList())
+            syncRemoteStore.deleteRemoteReadMarksForReadItems()
         }
         confirmVerified(feedItemStore, syncRemoteStore)
     }


### PR DESCRIPTION
- RssLocalSync: items applied via alreadyReadGuids path now receive a read_status_synced entry immediately after upsert. Previously the entry was never written, so getFeedItemsWithoutSyncedReadMark() would return these items on the next sync and echo them back to the server as a new read mark.

- SyncRestClient.getRead: latestMessageTimestamp is now advanced for corrupt (un-decryptable) marks before continuing. Previously the timestamp was only updated on success, so a single corrupt mark would cause the same mark to be retried on every subsequent sync.

- RemoteReadMarkDao / Repository.applyRemoteReadMarks: added deleteRemoteReadMarksForReadItems() which removes remote_read_mark rows for items that already have read_time set. Called at the end of applyRemoteReadMarks() so stale marks can no longer override a deliberate mark-as-unread on the next sync cycle.

Added tests:
- RssLocalSyncKtTest: remoteReadMarkIsAppliedToNewItemAndMarkedAsSynced, applyRemoteReadMarksCleansStaleEntriesForAlreadyReadItems, itemsNotInRemoteReadMarkAreNotMarkedAsRead
- SyncRestClientTest (new): getReadCallsRemoteMarkAsReadForEachReceivedMark, getReadAdvancesTimestampPastCorruptMark, markAsReadSendsItemsAndMarksThemAsSynced
- RepositoryTest: updated applyRemoteReadMarks + added applyRemoteReadMarksCleansUpStaleMarksEvenWhenNothingToApply
