### PR TITLE
refactor: cleaned up sync read-status layer

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/archmodel/Repository.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/archmodel/Repository.kt
@@ -719,7 +719,7 @@ class Repository(
         for (itemId in itemIds) {
             syncRemoteStore.setSynced(itemId)
         }
-        syncRemoteStore.deleteReadStatusSyncs(toBeApplied.map { it.id })
+        syncRemoteStore.deleteAppliedRemoteReadMarks(toBeApplied.map { it.id })
         // Remove stale marks for items that are already read so they don't override a
         // deliberate "mark as unread" on the next sync.
         syncRemoteStore.deleteRemoteReadMarksForReadItems()

--- a/app/src/main/java/com/nononsenseapps/feeder/archmodel/SyncRemoteStore.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/archmodel/SyncRemoteStore.kt
@@ -52,13 +52,9 @@ class SyncRemoteStore(
         readStatusDao.deleteAll()
     }
 
-    suspend fun deleteReadStatusSyncs(ids: List<Long>) {
-        readStatusDao.deleteReadStatusSyncs(ids)
+    suspend fun deleteAppliedRemoteReadMarks(ids: List<Long>) {
+        remoteReadMarkDao.deleteByIds(ids)
     }
-
-    fun getNextFeedItemWithoutSyncedReadMark(): Flow<FeedItemForReadMark?> = readStatusDao.getNextFeedItemWithoutSyncedReadMark()
-
-    fun getFlowOfFeedItemsWithoutSyncedReadMark(): Flow<List<FeedItemForReadMark>> = readStatusDao.getFlowOfFeedItemsWithoutSyncedReadMark()
 
     suspend fun getFeedItemsWithoutSyncedReadMark(): List<FeedItemForReadMark> = readStatusDao.getFeedItemsWithoutSyncedReadMark()
 

--- a/app/src/main/java/com/nononsenseapps/feeder/db/room/FeedItemDao.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/db/room/FeedItemDao.kt
@@ -349,12 +349,6 @@ interface FeedItemDao {
         readTime: Instant = Instant.now(),
     )
 
-    @Query("UPDATE feed_items SET read_time = coalesce(read_time, :readTime), notified = 1 WHERE id IS :id")
-    suspend fun markAsRead(
-        id: Long,
-        readTime: Instant = Instant.now(),
-    )
-
     @Query("UPDATE feed_items SET read_time = null WHERE id IS :id")
     suspend fun markAsUnread(id: Long)
 

--- a/app/src/main/java/com/nononsenseapps/feeder/db/room/ReadStatusSyncedDao.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/db/room/ReadStatusSyncedDao.kt
@@ -10,7 +10,6 @@ import com.nononsenseapps.feeder.db.COL_FEEDID
 import com.nononsenseapps.feeder.db.COL_FEEDURL
 import com.nononsenseapps.feeder.db.COL_GUID
 import com.nononsenseapps.feeder.db.COL_ID
-import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface ReadStatusSyncedDao {
@@ -29,54 +28,6 @@ interface ReadStatusSyncedDao {
         """,
     )
     suspend fun deleteAll(): Int
-
-    /**
-     * Sorts by id DESCENDING so new items always refreshes the flow
-     */
-    @Query(
-        """
-            SELECT 
-                fi.id AS $COL_ID,
-                f.id AS $COL_FEEDID,
-                fi.guid AS $COL_GUID,
-                f.url AS $COL_FEEDURL
-            FROM feed_items fi
-            JOIN feeds f ON f.id = fi.feed_id
-            WHERE
-                fi.read_time is not null AND
-                fi.id NOT IN (
-                    SELECT feed_item
-                    FROM read_status_synced
-                )
-            ORDER BY fi.id DESC
-            LIMIT 1
-        """,
-    )
-    fun getNextFeedItemWithoutSyncedReadMark(): Flow<FeedItemForReadMark?>
-
-    /**
-     * Limits to 100 items
-     */
-    @Query(
-        """
-            SELECT 
-                fi.id AS $COL_ID,
-                f.id AS $COL_FEEDID,
-                fi.guid AS $COL_GUID,
-                f.url AS $COL_FEEDURL
-            FROM feed_items fi
-            JOIN feeds f ON f.id = fi.feed_id
-            WHERE
-                fi.read_time is not null and
-                fi.id NOT IN (
-                    SELECT feed_item
-                    FROM read_status_synced
-                )
-            ORDER BY fi.id DESC
-            LIMIT 100
-        """,
-    )
-    fun getFlowOfFeedItemsWithoutSyncedReadMark(): Flow<List<FeedItemForReadMark>>
 
     @Query(
         """
@@ -97,14 +48,6 @@ interface ReadStatusSyncedDao {
         """,
     )
     suspend fun getFeedItemsWithoutSyncedReadMark(): List<FeedItemForReadMark>
-
-    @Query(
-        """
-            DELETE FROM remote_read_mark
-            WHERE id in (:ids)
-        """,
-    )
-    suspend fun deleteReadStatusSyncs(ids: List<Long>): Int
 
     @Query(
         """

--- a/app/src/main/java/com/nononsenseapps/feeder/db/room/RemoteReadMarkDao.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/db/room/RemoteReadMarkDao.kt
@@ -28,6 +28,18 @@ interface RemoteReadMarkDao {
     suspend fun deleteStaleRemoteReadMarks(oldestTimestamp: Instant): Int
 
     /**
+     * Deletes a set of remote read marks by their primary key ids.
+     * Used after the marks have been successfully applied locally.
+     */
+    @Query(
+        """
+            DELETE FROM remote_read_mark
+            WHERE id in (:ids)
+        """,
+    )
+    suspend fun deleteByIds(ids: List<Long>): Int
+
+    /**
      * Deletes remote read marks for items that have already been marked as read locally.
      * This prevents stale marks from re-applying a read status after the user has
      * explicitly marked an item as unread.

--- a/app/src/main/java/com/nononsenseapps/feeder/sync/SyncRestClient.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/sync/SyncRestClient.kt
@@ -78,14 +78,12 @@ class SyncRestClient(
         }
     }
 
-    private suspend fun <A> safeBlock(block: (suspend (SyncRemote, FeederSync, SecretKeys) -> Either<ErrorResponse, A>)?): Either<ErrorResponse, A> {
-        if (block != null) {
-            repository.getSyncRemote().let { syncRemote ->
-                if (syncRemote.hasSyncChain()) {
-                    feederSync?.let { feederSync ->
-                        secretKey?.let { secretKey ->
-                            return block(syncRemote, feederSync, secretKey)
-                        }
+    private suspend fun <A> safeBlock(block: suspend (SyncRemote, FeederSync, SecretKeys) -> Either<ErrorResponse, A>): Either<ErrorResponse, A> {
+        repository.getSyncRemote().let { syncRemote ->
+            if (syncRemote.hasSyncChain()) {
+                feederSync?.let { feederSync ->
+                    secretKey?.let { secretKey ->
+                        return block(syncRemote, feederSync, secretKey)
                     }
                 }
             }
@@ -269,7 +267,7 @@ class SyncRestClient(
             )
         }
 
-    internal suspend fun markAsRead(feedItems: List<FeedItemForReadMark>): Either<ErrorResponse, SendReadMarkResponse> =
+    private suspend fun sendReadMarksBatch(feedItems: List<FeedItemForReadMark>): Either<ErrorResponse, SendReadMarkResponse> =
         try {
             safeBlock { syncRemote, feederSync, secretKey ->
                 logDebug(LOG_TAG, "markAsRead: ${feedItems.size} items")
@@ -326,7 +324,7 @@ class SyncRestClient(
                         .asSequence()
                         .chunked(100)
                         .forEach { feedItems ->
-                            markAsRead(feedItems)
+                            sendReadMarksBatch(feedItems)
                         }
                 }
                 Either.Right(Unit)

--- a/app/src/test/java/com/nononsenseapps/feeder/archmodel/RepositoryTest.kt
+++ b/app/src/test/java/com/nononsenseapps/feeder/archmodel/RepositoryTest.kt
@@ -427,7 +427,7 @@ class RepositoryTest : DIAware {
             feedItemStore.markAsRead(listOf(2L, 4L))
             syncRemoteStore.setSynced(2L)
             syncRemoteStore.setSynced(4L)
-            syncRemoteStore.deleteReadStatusSyncs(listOf(1L, 3L))
+            syncRemoteStore.deleteAppliedRemoteReadMarks(listOf(1L, 3L))
             syncRemoteStore.deleteRemoteReadMarksForReadItems()
         }
         confirmVerified(feedItemStore, syncRemoteStore)
@@ -444,7 +444,7 @@ class RepositoryTest : DIAware {
         coVerify {
             syncRemoteStore.getRemoteReadMarksReadyToBeApplied()
             feedItemStore.markAsRead(emptyList())
-            syncRemoteStore.deleteReadStatusSyncs(emptyList())
+            syncRemoteStore.deleteAppliedRemoteReadMarks(emptyList())
             syncRemoteStore.deleteRemoteReadMarksForReadItems()
         }
         confirmVerified(feedItemStore, syncRemoteStore)

--- a/app/src/test/java/com/nononsenseapps/feeder/archmodel/SyncRemoteStoreTest.kt
+++ b/app/src/test/java/com/nononsenseapps/feeder/archmodel/SyncRemoteStoreTest.kt
@@ -12,7 +12,6 @@ import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
@@ -111,21 +110,6 @@ class SyncRemoteStoreTest : DIAware {
     }
 
     @Test
-    fun getNextFeedItemWithoutSyncedReadMark() {
-        coEvery { readStatusDao.getNextFeedItemWithoutSyncedReadMark() } returns emptyFlow()
-
-        val result =
-            runBlocking {
-                store.getNextFeedItemWithoutSyncedReadMark().toList()
-            }
-
-        assertEquals(emptyList(), result)
-
-        coVerify { readStatusDao.getNextFeedItemWithoutSyncedReadMark() }
-        confirmVerified(readStatusDao)
-    }
-
-    @Test
     fun setSynced() {
         coEvery { readStatusDao.insert(any()) } returns 10L
 
@@ -152,14 +136,14 @@ class SyncRemoteStoreTest : DIAware {
     }
 
     @Test
-    fun deleteReadStatusSyncs() {
-        coEvery { readStatusDao.deleteReadStatusSyncs(any()) } returns 50
+    fun deleteAppliedRemoteReadMarks() {
+        coEvery { remoteReadMarkDao.deleteByIds(any()) } returns 50
 
         runBlocking {
-            store.deleteReadStatusSyncs(listOf(5L, 12L))
+            store.deleteAppliedRemoteReadMarks(listOf(5L, 12L))
         }
 
-        coVerify { readStatusDao.deleteReadStatusSyncs(listOf(5L, 12L)) }
-        confirmVerified(readStatusDao)
+        coVerify { remoteReadMarkDao.deleteByIds(listOf(5L, 12L)) }
+        confirmVerified(remoteReadMarkDao)
     }
 }


### PR DESCRIPTION
1. Moved ReadStatusSyncedDao.deleteReadStatusSyncs to RemoteReadMarkDao.deleteByIds. The old method deleted from remote_read_mark inside a DAO named ReadStatusSyncedDao, which was confusing and caused misdirection during bug investigation. Renamed the SyncRemoteStore wrapper to deleteAppliedRemoteReadMarks to reflect its actual purpose.

2. Removed two dead Flow query variants (getNextFeedItemWithoutSynced ReadMark, getFlowOfFeedItemsWithoutSyncedReadMark) from ReadStatusSyncedDao and SyncRemoteStore. Neither was called from any production code; only the plain-suspend getFeedItemsWithoutSyncedReadMark() is used.

3. Removed FeedItemDao.markAsRead(id: Long), which had byte-for-byte identical SQL to markAsReadAndNotified(id: Long) and was never called from any production code.

4. Made SyncRestClient.safeBlock's block parameter non-nullable and removed the dead if (block != null) guard. Every call site already passes a non-null lambda.

5. Renamed internal markAsRead(feedItems) to private sendReadMarksBatch(feedItems) to disambiguate it from the public markAsRead() coordinator. The old identical names made the call from coordinator to sender look like recursion.
