### PR TITLE
feat: use feed entry id as fallback link.

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/model/gofeed/GoFeedExtensions.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/gofeed/GoFeedExtensions.kt
@@ -8,6 +8,7 @@ import com.nononsenseapps.feeder.util.findFirstImageInHtml
 import com.nononsenseapps.feeder.util.relativeLinkIntoAbsolute
 import com.nononsenseapps.feeder.util.relativeLinkIntoAbsoluteOrNull
 import okhttp3.internal.toLongOrDefault
+import java.net.URI
 import java.net.URL
 
 class FeederGoItem(
@@ -56,7 +57,18 @@ class FeederGoItem(
 
     val snippet: String by lazy { plainContent.take(200) }
 
-    val link: String? by lazy { goItem.link?.let { relativeLinkIntoAbsolute(feedBaseUrl, it) } }
+    val link: String? by lazy {
+        val rawLink =
+            goItem.link ?: goItem.guid?.takeIf { guid ->
+                try {
+                    val uri = URI(guid)
+                    uri.isAbsolute && (uri.scheme == "http" || uri.scheme == "https")
+                } catch (_: Exception) {
+                    false
+                }
+            }
+        rawLink?.let { relativeLinkIntoAbsolute(feedBaseUrl, it) }
+    }
 
     val updated: String?
         get() = goItem.updatedParsed

--- a/app/src/test/java/com/nononsenseapps/feeder/model/gofeed/GoFeedExtensionsKtTest.kt
+++ b/app/src/test/java/com/nononsenseapps/feeder/model/gofeed/GoFeedExtensionsKtTest.kt
@@ -37,6 +37,71 @@ class GoFeedExtensionsKtTest {
     }
 
     @Test
+    fun linkFallsBackToGuidWhenGuidIsUrl() {
+        val item =
+            FeederGoItem(
+                goItem =
+                    makeGoItem(
+                        guid = "https://example.com/article/123",
+                        link = null,
+                    ),
+                feedBaseUrl = baseUrl,
+                feedAuthor = null,
+            )
+
+        assertEquals("https://example.com/article/123", item.link)
+    }
+
+    @Test
+    fun linkDoesNotFallBackToGuidWhenGuidIsNonHttpUri() {
+        val item =
+            FeederGoItem(
+                goItem =
+                    makeGoItem(
+                        guid = "urn:uuid:some-non-url-id",
+                        link = null,
+                    ),
+                feedBaseUrl = baseUrl,
+                feedAuthor = null,
+            )
+
+        assertEquals(null, item.link)
+    }
+
+    @Test
+    fun linkDoesNotFallBackToGuidWhenGuidIsInvalidUri() {
+        // Double ## makes the fragment contain a bare '#', which is invalid in RFC 3986
+        val item =
+            FeederGoItem(
+                goItem =
+                    makeGoItem(
+                        guid = "http://example.com/sub/##",
+                        link = null,
+                    ),
+                feedBaseUrl = baseUrl,
+                feedAuthor = null,
+            )
+
+        assertEquals(null, item.link)
+    }
+
+    @Test
+    fun linkIsPreferredOverGuidWhenBothPresent() {
+        val item =
+            FeederGoItem(
+                goItem =
+                    makeGoItem(
+                        guid = "https://example.com/guid",
+                        link = "https://example.com/link",
+                    ),
+                feedBaseUrl = baseUrl,
+                feedAuthor = null,
+            )
+
+        assertEquals("https://example.com/link", item.link)
+    }
+
+    @Test
     fun feedThumbnailCandidateIsPreservedEvenWhenBodyFallbackIsChosen() {
         val imageUrl = "https://example.com/feed.jpg"
         val html = "<img src='$imageUrl' alt='Article image'/>"


### PR DESCRIPTION
## What does this change?

Some RSS feeds store entry links in the `<id>` field rather than in a separate `<link>` field. Example: https://jacobin.com/feed

```
...
<entry>
  <id>https://jacobin.com/2026/05/democrats-medicare-for-all-donor-class</id>
...
```

This change takes advantage of this by:
1. if `<link>` field is present, use that as the link.
2. if not, check if the `<id>` field is a valid absolute HTTP/S URL, and if so use that as the link.



<!-- Describe what this PR does and why. -->

## Checklist

- [x] Ran `./gradlew ktlintFormat` and committed the result
- [ ] If the Room schema changed: added a `MIGRATION_N_N+1` in `AppDatabase.kt`
- [ ] If the Room schema changed: added a migration test in `app/src/androidTest/.../db/room/`

## Screenshots (if UI change)
N/A
