### PR TITLE
docs: added logging conventions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,36 @@ A community-contributed feature. Users supply their own API keys via the Setting
 
 ---
 
+## Logging
+
+Always use the `logDebug` utility from `util/Logging.kt` instead of calling `android.util.Log.d` directly.
+`logDebug` is a no-op in production builds, so debug noise never reaches end users.
+
+```kotlin
+// Good
+import com.nononsenseapps.feeder.util.logDebug
+logDebug(LOG_TAG, "message")
+
+// Bad — leaks debug output to production
+android.util.Log.d("tag", "message")
+```
+
+For warnings and errors that should survive in production, `Log.w` / `Log.e` are fine to use directly.
+
+### Log tag convention
+
+- Declare the tag as a constant named `LOG_TAG` in the class's companion object (or at file scope for top-level code).
+- The value must be `SCREAMING_SNAKE_CASE` and **prefixed with `FEEDER_`**.
+- Keep it short enough to stay within Android's 23-character tag limit.
+
+```kotlin
+companion object {
+    private const val LOG_TAG = "FEEDER_MY_COMPONENT"
+}
+```
+
+---
+
 ## Things to avoid
 
 - Do **not** introduce new DI frameworks (Hilt, Dagger, etc.). Use Kodein.

--- a/app/src/main/java/com/nononsenseapps/feeder/archmodel/SyncRemoteStore.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/archmodel/SyncRemoteStore.kt
@@ -129,6 +129,6 @@ class SyncRemoteStore(
     }
 
     companion object {
-        private const val LOG_TAG = "FEEDER_SyncRemoteStore"
+        private const val LOG_TAG = "FEEDER_SYNC_REMOTE"
     }
 }

--- a/app/src/main/java/com/nononsenseapps/feeder/background/FeederJobService.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/background/FeederJobService.kt
@@ -110,6 +110,6 @@ class FeederJobService : DIAwareJobService() {
     }
 
     companion object {
-        private const val LOG_TAG = "FeederJobService"
+        private const val LOG_TAG = "FEEDER_JOB_SERVICE"
     }
 }

--- a/app/src/main/java/com/nononsenseapps/feeder/model/ReadAloudStateHolder.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/ReadAloudStateHolder.kt
@@ -309,7 +309,7 @@ class TTSStateHolder(
     }
 
     companion object {
-        private const val LOG_TAG = "FeederTextToSpeech"
+        private const val LOG_TAG = "FEEDER_TTS"
         private val PUNCTUATION =
             arrayOf(
                 // New-lines

--- a/app/src/main/java/com/nononsenseapps/feeder/model/RssLocalSync.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/RssLocalSync.kt
@@ -556,7 +556,7 @@ class RssLocalSync(
     }
 
     companion object {
-        private const val LOG_TAG = "FEEDER_RssLocalSync"
+        private const val LOG_TAG = "FEEDER_RSS_LOCAL_SYNC"
     }
 }
 


### PR DESCRIPTION
Also fixed non-conforming LOG_TAG values to use SCREAMING_SNAKE_CASE with FEEDER_ prefix and stay within Android's 23-character tag limit.
