### PR TITLE
fix: corrected defaults causing AI translation appear enabled on upgrade

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/archmodel/SettingsStore.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/archmodel/SettingsStore.kt
@@ -509,7 +509,7 @@ class SettingsStore(
         MutableStateFlow(
             OpenAISettings(
                 key = sp.getStringNonNull(PREF_OPENAI_KEY, ""),
-                modelId = sp.getStringNonNull(PREF_OPENAI_MODEL_ID, "gpt-4o-mini"),
+                modelId = sp.getStringNonNull(PREF_OPENAI_MODEL_ID, ""),
                 baseUrl = sp.getStringNonNull(PREF_OPENAI_URL, ""),
                 azureApiVersion = sp.getStringNonNull(PREF_OPENAI_AZURE_VERSION, ""),
                 azureDeploymentId = sp.getStringNonNull(PREF_OPENAI_AZURE_DEPLOYMENT_ID, ""),


### PR DESCRIPTION
Previously, the Summary API settings were initialised with a hardcoded fallback of "gpt-4o-mini" for the model ID preference. For users who had never configured the AI feature, this non-blank value caused isBlankConfiguration to return false, which made AIProviderPreset resolve to OPENAI_COMPATIBLE instead of NONE. Opening Settings then showed an "Enter an API key before saving" validation message even though the user had never opted in to any AI provider.

Fixed by changing the fallback default for PREF_OPENAI_MODEL_ID to an empty string, so unconfigured installations correctly resolve to NONE.

Closes #1152
