### PR TITLE
add setting for max article size

### DIFF
--- a/app/src/androidTest/java/com/nononsenseapps/feeder/model/opml/OPMLTest.kt
+++ b/app/src/androidTest/java/com/nononsenseapps/feeder/model/opml/OPMLTest.kt
@@ -792,6 +792,7 @@ class OPMLTest : DIAware {
                         UserSettings.SETTING_TRANSLATION_API_REQUEST_TIMEOUT_SECONDS -> "90"
                         UserSettings.SETTING_TRANSLATE_ARTICLE_PREVIEWS_BY_DEFAULT -> "true"
                         UserSettings.SETTING_TRANSLATE_ARTICLES_BY_DEFAULT -> "false"
+                        UserSettings.SETTING_MAX_ARTICLE_SIZE -> "MB_1"
                     }
             }
     }
@@ -879,6 +880,7 @@ private val sampleFile: List<String> =
           <feeder:setting key="pref_translation_api_request_timeout_seconds" value="90"/>
           <feeder:setting key="pref_translate_feed_cards_by_default" value="true"/>
           <feeder:setting key="pref_translate_articles_by_default" value="false"/>
+          <feeder:setting key="pref_max_article_size" value="MB_1"/>
           <feeder:blocked pattern="foo"/>
         </feeder:settings>
       </body>

--- a/app/src/main/java/com/nononsenseapps/feeder/archmodel/Repository.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/archmodel/Repository.kt
@@ -159,6 +159,12 @@ class Repository(
         settingsStore.setMaxLines(value.coerceAtLeast(1))
     }
 
+    val maxArticleSize: StateFlow<MaxArticleSize> = settingsStore.maxArticleSize
+
+    fun setMaxArticleSize(value: MaxArticleSize) {
+        settingsStore.setMaxArticleSize(value)
+    }
+
     val showOnlyTitle: StateFlow<Boolean> = settingsStore.showOnlyTitle
 
     fun setShowOnlyTitles(value: Boolean) {

--- a/app/src/main/java/com/nononsenseapps/feeder/archmodel/SettingsStore.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/archmodel/SettingsStore.kt
@@ -437,6 +437,22 @@ class SettingsStore(
             ).apply()
     }
 
+    private val _maxArticleSize =
+        MutableStateFlow(
+            maxArticleSizeFromString(
+                sp.getStringNonNull(PREF_MAX_ARTICLE_SIZE, MaxArticleSize.MB_1.name),
+            ),
+        )
+    val maxArticleSize: StateFlow<MaxArticleSize> = _maxArticleSize.asStateFlow()
+
+    fun setMaxArticleSize(value: MaxArticleSize) {
+        _maxArticleSize.value = value
+        sp
+            .edit()
+            .putString(PREF_MAX_ARTICLE_SIZE, value.name)
+            .apply()
+    }
+
     private val _swipeAsRead =
         MutableStateFlow(
             swipeAsReadFromString(
@@ -695,6 +711,7 @@ const val PREF_FONT = "pref_font"
 const val PREF_IS_MARK_AS_READ_ON_SCROLL = "pref_is_mark_as_read_on_scroll"
 
 const val PREF_MAX_LINES = "pref_max_lines"
+const val PREF_MAX_ARTICLE_SIZE = "pref_max_article_size"
 
 const val PREFS_FILTER_SAVED = "prefs_filter_saved"
 const val PREFS_FILTER_RECENTLY_READ = "prefs_filter_recently_read"
@@ -797,6 +814,7 @@ enum class UserSettings(
     SETTING_TRANSLATION_API_REQUEST_TIMEOUT_SECONDS(key = PREF_TRANSLATION_API_REQUEST_TIMEOUT_SECONDS),
     SETTING_TRANSLATE_ARTICLE_PREVIEWS_BY_DEFAULT(key = PREF_TRANSLATE_ARTICLE_PREVIEWS_BY_DEFAULT),
     SETTING_TRANSLATE_ARTICLES_BY_DEFAULT(key = PREF_TRANSLATE_ARTICLES_BY_DEFAULT),
+    SETTING_MAX_ARTICLE_SIZE(key = PREF_MAX_ARTICLE_SIZE),
     ;
 
     companion object {
@@ -854,6 +872,19 @@ enum class SyncFrequency(
     EVERY_6_HOURS(360L, R.string.sync_option_every_6_hours),
     EVERY_12_HOURS(720L, R.string.sync_option_every_12_hours),
     EVERY_DAY(1440L, R.string.sync_option_every_day),
+}
+
+enum class MaxArticleSize(
+    val bytes: Int,
+    @StringRes val stringId: Int,
+) {
+    MB_1(1 * 1024 * 1024, R.string.max_article_size_1mb),
+    MB_2(2 * 1024 * 1024, R.string.max_article_size_2mb),
+    MB_4(4 * 1024 * 1024, R.string.max_article_size_4mb),
+    MB_5(5 * 1024 * 1024, R.string.max_article_size_5mb),
+    MB_8(8 * 1024 * 1024, R.string.max_article_size_8mb),
+    MB_10(10 * 1024 * 1024, R.string.max_article_size_10mb),
+    UNLIMITED(Int.MAX_VALUE, R.string.max_article_size_unlimited),
 }
 
 enum class FeedItemStyle(
@@ -953,6 +984,13 @@ fun syncFrequencyFromString(value: String) =
             it.minutes == value.toLongOrNull()
         }
         ?: SyncFrequency.MANUAL
+
+fun maxArticleSizeFromString(value: String): MaxArticleSize =
+    try {
+        MaxArticleSize.valueOf(value.uppercase())
+    } catch (_: Exception) {
+        MaxArticleSize.MB_1
+    }
 
 data class PrefsFeedListFilter(
     override val saved: Boolean,

--- a/app/src/main/java/com/nononsenseapps/feeder/model/FullTextParser.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/FullTextParser.kt
@@ -83,24 +83,33 @@ class FullTextParser(
                     ) {
                         val body = response.body
 
+                        val maxBytesLimit =
+                            repository.maxArticleSize.value.bytes
+                                .toLong()
+
                         val contentLength = body.contentLength()
-                        if (contentLength > MAX_FULL_TEXT_BYTES) {
-                            return@catching FullTextTooLarge(url = url, maxBytes = MAX_FULL_TEXT_BYTES).left()
+                        if (contentLength > maxBytesLimit) {
+                            return@catching FullTextTooLarge(
+                                url = url,
+                                maxBytes = maxBytesLimit.toInt(),
+                            ).left()
                         }
 
-                        val maxBytes = MAX_FULL_TEXT_BYTES.toLong()
                         val buffer = okio.Buffer()
 
                         body.use {
                             val source = body.source()
-                            while (buffer.size <= maxBytes) {
+                            while (buffer.size <= maxBytesLimit) {
                                 val read = source.read(buffer, 8_192)
                                 if (read == -1L) break
                             }
                         }
 
-                        if (buffer.size > maxBytes) {
-                            return@catching FullTextTooLarge(url = url, maxBytes = MAX_FULL_TEXT_BYTES).left()
+                        if (buffer.size > maxBytesLimit) {
+                            return@catching FullTextTooLarge(
+                                url = url,
+                                maxBytes = maxBytesLimit.toInt(),
+                            ).left()
                         }
 
                         val bytes = buffer.readByteArray()

--- a/app/src/main/java/com/nononsenseapps/feeder/model/html/HtmlLinearizer.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/html/HtmlLinearizer.kt
@@ -20,6 +20,8 @@ class HtmlLinearizer(
     private val tooLargeText: String,
     private val openInBrowserText: String,
     private val articleLink: String,
+    private val maxElements: Int = MAX_ELEMENTS,
+    private val maxChars: Int = MAX_CHARS,
 ) {
     private var linearTextBuilder: LinearTextBuilder = LinearTextBuilder()
     private var idHolder: IdHolder = {
@@ -768,7 +770,7 @@ class HtmlLinearizer(
     private fun ListBuilderScope<LinearElement>.addLimited(element: LinearElement) {
         if (truncated) return
         elementCount++
-        if (elementCount > MAX_ELEMENTS || charCount > MAX_CHARS) {
+        if (elementCount > maxElements || charCount > maxChars) {
             truncated = true
             Log.w(LOG_TAG, "LinearArticle limits reached. Elements: $elementCount, Chars: $charCount. Truncating...")
             return

--- a/app/src/main/java/com/nononsenseapps/feeder/model/opml/OPMLImporter.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/opml/OPMLImporter.kt
@@ -8,6 +8,7 @@ import com.nononsenseapps.feeder.archmodel.defaultFont
 import com.nononsenseapps.feeder.archmodel.feedItemStyleFromString
 import com.nononsenseapps.feeder.archmodel.itemOpenerFromString
 import com.nononsenseapps.feeder.archmodel.linkOpenerFromString
+import com.nononsenseapps.feeder.archmodel.maxArticleSizeFromString
 import com.nononsenseapps.feeder.archmodel.sortingOptionsFromString
 import com.nononsenseapps.feeder.archmodel.swipeAsReadFromString
 import com.nononsenseapps.feeder.archmodel.syncFrequencyFromString
@@ -156,6 +157,7 @@ open class OPMLImporter(
                 settingsStore.setTranslationApiSettings(newSettings)
             }
             UserSettings.SETTING_BLOCKLIST_APPLY_TO_SUMMARIES -> settingsStore.setApplyBlocklistToSummaries(value.toBoolean())
+            UserSettings.SETTING_MAX_ARTICLE_SIZE -> settingsStore.setMaxArticleSize(maxArticleSizeFromString(value))
         }
     }
 

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleViewModel.kt
@@ -11,6 +11,7 @@ import com.nononsenseapps.feeder.R
 import com.nononsenseapps.feeder.archmodel.Article
 import com.nononsenseapps.feeder.archmodel.Enclosure
 import com.nononsenseapps.feeder.archmodel.LinkOpener
+import com.nononsenseapps.feeder.archmodel.MaxArticleSize
 import com.nononsenseapps.feeder.archmodel.OpenAISettings
 import com.nononsenseapps.feeder.archmodel.Repository
 import com.nononsenseapps.feeder.archmodel.TextToDisplay
@@ -104,7 +105,8 @@ class ArticleViewModel(
         combine(
             articleFlow,
             displayFullTextOverride,
-        ) { article, fullTextOverride ->
+            repository.maxArticleSize,
+        ) { article, fullTextOverride, _ ->
             article?.let {
                 it to (fullTextOverride ?: it.fullTextByDefault)
             }
@@ -305,11 +307,14 @@ class ArticleViewModel(
         logDebug(LOG_TAG, "parseArticleContent(${article.id}, $fullText)")
         return try {
             withContext(Dispatchers.IO) {
+                val sizeLimit = repository.maxArticleSize.value
                 val htmlLinearizer =
                     HtmlLinearizer(
                         tooLargeText = application.getString(R.string.failed_to_fetch_full_article_too_large),
                         openInBrowserText = application.getString(R.string.open_in_web_view),
                         articleLink = article.link ?: "",
+                        maxElements = if (sizeLimit == MaxArticleSize.UNLIMITED) Int.MAX_VALUE else HtmlLinearizer.MAX_ELEMENTS,
+                        maxChars = if (sizeLimit == MaxArticleSize.UNLIMITED) Int.MAX_VALUE else HtmlLinearizer.MAX_CHARS,
                     )
                 when (fullText) {
                     false -> {
@@ -381,13 +386,11 @@ class ArticleViewModel(
                                         textToDisplay.update { TextToDisplay.CONTENT }
                                     }
                             } catch (e: Exception) {
-                                // EOFException is possible
                                 Log.e(LOG_TAG, "Could not open blob", e)
                                 textToDisplay.update { TextToDisplay.FAILED_TO_LOAD_FULLTEXT }
                                 LinearArticle(elements = emptyList())
                             }
                         } else {
-                            // Error text should already be set above
                             LinearArticle(elements = emptyList())
                         }
                     }
@@ -591,11 +594,14 @@ class ArticleViewModel(
                         isFullText = fullText,
                     ) ?: throw IllegalStateException("Translation failed")
 
+                val sizeLimit = repository.maxArticleSize.value
                 translatedArticleContent.value =
                     HtmlLinearizer(
                         tooLargeText = application.getString(R.string.failed_to_fetch_full_article_too_large),
                         openInBrowserText = application.getString(R.string.open_in_web_view),
                         articleLink = article.link ?: "",
+                        maxElements = if (sizeLimit == MaxArticleSize.UNLIMITED) Int.MAX_VALUE else HtmlLinearizer.MAX_ELEMENTS,
+                        maxChars = if (sizeLimit == MaxArticleSize.UNLIMITED) Int.MAX_VALUE else HtmlLinearizer.MAX_CHARS,
                     ).linearize(
                         translation.translatedHtml,
                         article.feedUrl ?: "",

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/settings/Settings.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/settings/Settings.kt
@@ -83,6 +83,7 @@ import com.nononsenseapps.feeder.archmodel.DarkThemePreferences
 import com.nononsenseapps.feeder.archmodel.FeedItemStyle
 import com.nononsenseapps.feeder.archmodel.ItemOpener
 import com.nononsenseapps.feeder.archmodel.LinkOpener
+import com.nononsenseapps.feeder.archmodel.MaxArticleSize
 import com.nononsenseapps.feeder.archmodel.SortingOptions
 import com.nononsenseapps.feeder.archmodel.SwipeAsRead
 import com.nononsenseapps.feeder.archmodel.SyncFrequency
@@ -224,6 +225,8 @@ fun SettingsScreen(
             onIsPagingModeChange = settingsViewModel::setIsPagingMode,
             isAnimatedPaging = viewState.isAnimatedPaging,
             onIsAnimatedPagingChange = settingsViewModel::setIsAnimatedPaging,
+            maxArticleSize = viewState.maxArticleSize,
+            onMaxArticleSizeChange = settingsViewModel::setMaxArticleSize,
             onSendFeedback = {
                 activityLauncher.startActivity(
                     openAdjacentIfSuitable = true,
@@ -316,6 +319,8 @@ private fun SettingsScreenPreview() {
             onIsPagingModeChange = {},
             isAnimatedPaging = false,
             onIsAnimatedPagingChange = {},
+            maxArticleSize = MaxArticleSize.MB_1,
+            onMaxArticleSizeChange = {},
             onSendFeedback = {},
             modifier = Modifier,
         )
@@ -398,6 +403,8 @@ fun SettingsList(
     onIsPagingModeChange: (Boolean) -> Unit,
     isAnimatedPaging: Boolean,
     onIsAnimatedPagingChange: (Boolean) -> Unit,
+    maxArticleSize: MaxArticleSize,
+    onMaxArticleSizeChange: (MaxArticleSize) -> Unit,
     onTextSettings: () -> Unit,
     onSendFeedback: () -> Unit,
     modifier: Modifier = Modifier,
@@ -753,6 +760,39 @@ fun SettingsList(
                     checked = isAnimatedPaging,
                     onCheckedChange = onIsAnimatedPagingChange,
                     description = stringResource(id = R.string.pref_animated_paging_description),
+                )
+            }
+
+            MenuSetting(
+                title = stringResource(id = R.string.max_article_size),
+                currentValue = maxArticleSize.asMaxArticleSizeOption(),
+                values =
+                    immutableListHolderOf(
+                        MaxArticleSize.MB_1.asMaxArticleSizeOption(),
+                        MaxArticleSize.MB_2.asMaxArticleSizeOption(),
+                        MaxArticleSize.MB_4.asMaxArticleSizeOption(),
+                        MaxArticleSize.MB_5.asMaxArticleSizeOption(),
+                        MaxArticleSize.MB_8.asMaxArticleSizeOption(),
+                        MaxArticleSize.MB_10.asMaxArticleSizeOption(),
+                        MaxArticleSize.UNLIMITED.asMaxArticleSizeOption(),
+                    ),
+                onSelection = {
+                    onMaxArticleSizeChange(it.maxArticleSize)
+                },
+                modifier =
+                    Modifier
+                        .width(dimens.maxContentWidth),
+            )
+
+            if (maxArticleSize != MaxArticleSize.MB_1) {
+                Text(
+                    text = stringResource(id = R.string.max_article_size_warning),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier =
+                        Modifier
+                            .width(dimens.maxContentWidth)
+                            .padding(horizontal = 16.dp, vertical = 4.dp),
                 )
             }
         }
@@ -1523,5 +1563,20 @@ fun FeedItemStyle.asFeedItemStyleOption() =
 fun SwipeAsRead.asSwipeAsReadOption() =
     SwipeAsReadOption(
         swipeAsRead = this,
+        name = stringResource(id = stringId),
+    )
+
+@Immutable
+data class MaxArticleSizeOption(
+    val maxArticleSize: MaxArticleSize,
+    val name: String,
+) {
+    override fun toString() = name
+}
+
+@Composable
+fun MaxArticleSize.asMaxArticleSizeOption() =
+    MaxArticleSizeOption(
+        maxArticleSize = this,
         name = stringResource(id = stringId),
     )

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/settings/SettingsViewModel.kt
@@ -10,6 +10,7 @@ import com.nononsenseapps.feeder.archmodel.DarkThemePreferences
 import com.nononsenseapps.feeder.archmodel.FeedItemStyle
 import com.nononsenseapps.feeder.archmodel.ItemOpener
 import com.nononsenseapps.feeder.archmodel.LinkOpener
+import com.nononsenseapps.feeder.archmodel.MaxArticleSize
 import com.nononsenseapps.feeder.archmodel.OpenAISettings
 import com.nononsenseapps.feeder.archmodel.Repository
 import com.nononsenseapps.feeder.archmodel.SortingOptions
@@ -204,6 +205,10 @@ class SettingsViewModel(
         repository.setPreferredTranslationLanguage(value)
     }
 
+    fun setMaxArticleSize(value: MaxArticleSize) {
+        repository.setMaxArticleSize(value)
+    }
+
     private val summaryOpenAIModelsState = MutableStateFlow<OpenAIModelsState>(OpenAIModelsState.None)
     private val translationApiModelsState = MutableStateFlow<TranslationApiModelsState>(OpenAIModelsState.None)
 
@@ -272,6 +277,7 @@ class SettingsViewModel(
                 repository.font,
                 repository.isPagingMode,
                 repository.isAnimatedPaging,
+                repository.maxArticleSize,
             ) { params: Array<Any> ->
                 @Suppress("UNCHECKED_CAST")
                 SettingsViewState(
@@ -320,6 +326,7 @@ class SettingsViewModel(
                     font = params[35] as FontSelection,
                     isPagingMode = params[36] as Boolean,
                     isAnimatedPaging = params[37] as Boolean,
+                    maxArticleSize = params[38] as MaxArticleSize,
                 )
             }.collect {
                 _viewState.value = it
@@ -412,6 +419,7 @@ data class SettingsViewState(
     val font: FontSelection = SystemDefault,
     val isPagingMode: Boolean = false,
     val isAnimatedPaging: Boolean = false,
+    val maxArticleSize: MaxArticleSize = MaxArticleSize.MB_1,
 )
 
 data class UIFeedSettings(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,6 +109,16 @@
   <string name="max_feed_items">Max items per feed</string>
   <string name="could_not_load_url">Could not load URL</string>
 
+  <string name="max_article_size">Maximum article size</string>
+  <string name="max_article_size_1mb">1 MB (default)</string>
+  <string name="max_article_size_2mb">2 MB</string>
+  <string name="max_article_size_4mb">4 MB</string>
+  <string name="max_article_size_5mb">5 MB</string>
+  <string name="max_article_size_8mb">8 MB</string>
+  <string name="max_article_size_10mb">10 MB</string>
+  <string name="max_article_size_unlimited">Unlimited</string>
+  <string name="max_article_size_warning">Warning: values above 1 MB may cause crashes on low-memory devices.</string>
+
   <string name="theme_system">System</string>
   <string name="theme_automatic">Auto</string>
   <string name="theme_day">Day</string>

--- a/app/src/test/java/com/nononsenseapps/feeder/model/opml/OpmlParserTest.kt
+++ b/app/src/test/java/com/nononsenseapps/feeder/model/opml/OpmlParserTest.kt
@@ -4,6 +4,7 @@ import com.nononsenseapps.feeder.archmodel.DarkThemePreferences
 import com.nononsenseapps.feeder.archmodel.FeedItemStyle
 import com.nononsenseapps.feeder.archmodel.ItemOpener
 import com.nononsenseapps.feeder.archmodel.LinkOpener
+import com.nononsenseapps.feeder.archmodel.MaxArticleSize
 import com.nononsenseapps.feeder.archmodel.OpenAISettings
 import com.nononsenseapps.feeder.archmodel.PREF_VAL_OPEN_WITH_CUSTOM_TAB
 import com.nononsenseapps.feeder.archmodel.SettingsStore
@@ -101,6 +102,7 @@ class OpmlParserTest : DIAware {
                         UserSettings.SETTING_TRANSLATION_API_REQUEST_TIMEOUT_SECONDS -> "90"
                         UserSettings.SETTING_TRANSLATE_ARTICLE_PREVIEWS_BY_DEFAULT -> "true"
                         UserSettings.SETTING_TRANSLATE_ARTICLES_BY_DEFAULT -> "true"
+                        UserSettings.SETTING_MAX_ARTICLE_SIZE -> "MB_1"
                     },
             )
         }
@@ -113,6 +115,7 @@ class OpmlParserTest : DIAware {
             every { settingsStore.translationApiSettings } returns MutableStateFlow(TranslationApiSettings())
             every { settingsStore.setOpenAiSettings(any()) } just Runs
             every { settingsStore.setTranslationApiSettings(any()) } just Runs
+            every { settingsStore.setMaxArticleSize(any()) } just Runs
             setAllSettings()
             verify {
                 settingsStore.setLinkOpener(LinkOpener.CUSTOM_TAB)
@@ -155,6 +158,7 @@ class OpmlParserTest : DIAware {
                 settingsStore.setTranslateArticlePreviewsByDefault(true)
                 settingsStore.setTranslateArticlesByDefault(true)
                 settingsStore.setApplyBlocklistToSummaries(true)
+                settingsStore.setMaxArticleSize(MaxArticleSize.MB_1)
             }
 
             confirmVerified(settingsStore)

--- a/app/src/test/java/com/nononsenseapps/feeder/model/opml/OpmlWriterKtTest.kt
+++ b/app/src/test/java/com/nononsenseapps/feeder/model/opml/OpmlWriterKtTest.kt
@@ -162,6 +162,7 @@ class OpmlWriterKtTest {
               <feeder:setting key="pref_translation_api_request_timeout_seconds" value="90"/>
               <feeder:setting key="pref_translate_feed_cards_by_default" value="true"/>
               <feeder:setting key="pref_translate_articles_by_default" value="true"/>
+              <feeder:setting key="pref_max_article_size" value="MB_1"/>
               <feeder:blocked pattern="foo"/>
               <feeder:blocked pattern="break &quot;xml id &apos;9&apos; &gt; 0 &amp; &lt; 10"/>
             </feeder:settings>
@@ -222,6 +223,7 @@ class OpmlWriterKtTest {
                         UserSettings.SETTING_TRANSLATION_API_REQUEST_TIMEOUT_SECONDS -> "90"
                         UserSettings.SETTING_TRANSLATE_ARTICLE_PREVIEWS_BY_DEFAULT -> "true"
                         UserSettings.SETTING_TRANSLATE_ARTICLES_BY_DEFAULT -> "true"
+                        UserSettings.SETTING_MAX_ARTICLE_SIZE -> "MB_1"
                     }
             }
     }


### PR DESCRIPTION
add setting for max article size. this fixes an issue, introduced with the oom fix for large articles, that on devices with enough memory that dont crash they can't be displayed anymore