### PR TITLE
fix: restored scroll position indicator in the article reader

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ReaderView.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ReaderView.kt
@@ -71,12 +71,12 @@ import com.nononsenseapps.feeder.ui.compose.theme.PreviewTheme
 import com.nononsenseapps.feeder.ui.compose.utils.ProvideScaledText
 import com.nononsenseapps.feeder.ui.compose.utils.ScreenType
 import com.nononsenseapps.feeder.ui.compose.utils.focusableInNonTouchMode
+import my.nanihadesuka.compose.ColumnScrollbar
+import my.nanihadesuka.compose.ScrollbarSettings
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.util.Locale
 import kotlin.math.roundToInt
-import my.nanihadesuka.compose.ColumnScrollbar
-import my.nanihadesuka.compose.ScrollbarSettings
 
 val dateTimeFormat: DateTimeFormatter =
     DateTimeFormatter

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ReaderView.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ReaderView.kt
@@ -75,6 +75,8 @@ import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.util.Locale
 import kotlin.math.roundToInt
+import my.nanihadesuka.compose.ColumnScrollbar
+import my.nanihadesuka.compose.ScrollbarSettings
 
 val dateTimeFormat: DateTimeFormatter =
     DateTimeFormatter
@@ -106,256 +108,264 @@ fun ReaderView(
         }
 
     SelectionContainer {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            modifier =
-                modifier
-                    .fillMaxWidth()
-                    .verticalScroll(articleScrollState)
-                    .padding(
-                        start =
-                            when (screenType) {
-                                ScreenType.DUAL -> 0.dp // List items have enough padding
-                                ScreenType.SINGLE -> dimens.margin
-                            },
-                        end = dimens.margin,
-                    ).focusGroup()
-                    .safeSemantics {
-                        testTag = "readerColumn"
-                    },
+        ColumnScrollbar(
+            state = articleScrollState,
+            settings =
+                ScrollbarSettings.Default.copy(
+                    thumbUnselectedColor = MaterialTheme.colorScheme.outlineVariant,
+                ),
         ) {
-            var offsetCounter = 1
-            run {
-                val goToFeedLabel = stringResource(R.string.go_to_feed, feedTitle)
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                    modifier =
-                        Modifier
-                            .width(dimens.maxReaderWidth)
-                            .semantics(mergeDescendants = true) {
-                                try {
-                                    customActions =
-                                        listOf(
-                                            // TODO enclosure?
-                                            CustomAccessibilityAction(goToFeedLabel) {
-                                                onFeedTitleClick()
-                                                true
-                                            },
-                                        )
-                                } catch (e: Exception) {
-                                    // Observed nullpointer exception when setting customActions
-                                    // No clue why it could be null
-                                    Log.e("FeederReaderScreen", "Exception in semantics", e)
-                                }
-                            },
-                ) {
-                    if (articleTitle.isNotBlank()) {
-                        WithBidiDeterminedLayoutDirection(paragraph = articleTitle) {
-                            val interactionSource = remember { MutableInteractionSource() }
-                            Text(
-                                text = articleTitle,
-                                style = MaterialTheme.typography.headlineLarge,
-                                modifier =
-                                    Modifier
-                                        .indication(interactionSource, LocalIndication.current)
-                                        .focusableInNonTouchMode(interactionSource = interactionSource)
-                                        .width(dimens.maxReaderWidth),
-                            )
-                        }
-                    }
-                    ProvideScaledText(
-                        style =
-                            MaterialTheme.typography.titleMedium.merge(
-                                LinkTextStyle(),
-                            ),
-                    ) {
-                        WithBidiDeterminedLayoutDirection(paragraph = feedTitle) {
-                            Text(
-                                text = feedTitle,
-                                modifier =
-                                    Modifier
-                                        .width(dimens.maxReaderWidth)
-                                        .clearAndSetSemantics {
-                                            contentDescription = feedTitle
-                                        }.clickable {
-                                            onFeedTitleClick()
-                                        },
-                            )
-                        }
-                    }
-                    if (authorDate != null) {
-                        ProvideScaledText(style = MaterialTheme.typography.titleMedium) {
-                            CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
-                                WithBidiDeterminedLayoutDirection(paragraph = authorDate) {
-                                    val interactionSource = remember { MutableInteractionSource() }
-                                    Text(
-                                        text = authorDate,
-                                        modifier =
-                                            Modifier
-                                                .width(dimens.maxReaderWidth)
-                                                .indication(interactionSource, LocalIndication.current)
-                                                .focusableInNonTouchMode(interactionSource = interactionSource),
-                                    )
-                                }
-                            }
-                        }
-                    }
-                    if (readTimeSecs > 0) {
-                        ProvideScaledText(style = MaterialTheme.typography.titleMedium) {
-                            CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
-                                Row(
-                                    horizontalArrangement = Arrangement.spacedBy(4.dp),
-                                    verticalAlignment = Alignment.CenterVertically,
-                                    modifier = Modifier.width(dimens.maxReaderWidth),
-                                ) {
-                                    Icon(
-                                        imageVector = Icons.Outlined.Timelapse,
-                                        contentDescription = null,
-                                    )
-                                    val seconds = "%02d".format(readTimeSecs % 60)
-                                    val readTimeText =
-                                        pluralStringResource(
-                                            id = R.plurals.n_minutes,
-                                            count = readTimeSecs / 60,
-                                        ).format(
-                                            "${readTimeSecs / 60}:$seconds",
-                                        )
-                                    WithBidiDeterminedLayoutDirection(paragraph = readTimeText) {
-                                        val interactionSource =
-                                            remember { MutableInteractionSource() }
-                                        Text(
-                                            text = readTimeText,
-                                            modifier =
-                                                Modifier
-                                                    .weight(1f)
-                                                    .indication(
-                                                        interactionSource,
-                                                        LocalIndication.current,
-                                                    ).focusableInNonTouchMode(interactionSource = interactionSource),
-                                        )
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (enclosure.present) {
-                offsetCounter++
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                modifier =
+                    modifier
+                        .fillMaxWidth()
+                        .verticalScroll(articleScrollState)
+                        .padding(
+                            start =
+                                when (screenType) {
+                                    ScreenType.DUAL -> 0.dp // List items have enough padding
+                                    ScreenType.SINGLE -> dimens.margin
+                                },
+                            end = dimens.margin,
+                        ).focusGroup()
+                        .safeSemantics {
+                            testTag = "readerColumn"
+                        },
+            ) {
+                var offsetCounter = 1
                 run {
-                    // Image will be shown in block below
-                    if (!enclosure.isImage) {
-                        val openLabel =
-                            if (enclosure.name.isBlank()) {
-                                stringResource(R.string.open_enclosed_media)
-                            } else {
-                                stringResource(R.string.open_enclosed_media_file, enclosure.name)
+                    val goToFeedLabel = stringResource(R.string.go_to_feed, feedTitle)
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier =
+                            Modifier
+                                .width(dimens.maxReaderWidth)
+                                .semantics(mergeDescendants = true) {
+                                    try {
+                                        customActions =
+                                            listOf(
+                                                // TODO enclosure?
+                                                CustomAccessibilityAction(goToFeedLabel) {
+                                                    onFeedTitleClick()
+                                                    true
+                                                },
+                                            )
+                                    } catch (e: Exception) {
+                                        // Observed nullpointer exception when setting customActions
+                                        // No clue why it could be null
+                                        Log.e("FeederReaderScreen", "Exception in semantics", e)
+                                    }
+                                },
+                    ) {
+                        if (articleTitle.isNotBlank()) {
+                            WithBidiDeterminedLayoutDirection(paragraph = articleTitle) {
+                                val interactionSource = remember { MutableInteractionSource() }
+                                Text(
+                                    text = articleTitle,
+                                    style = MaterialTheme.typography.headlineLarge,
+                                    modifier =
+                                        Modifier
+                                            .indication(interactionSource, LocalIndication.current)
+                                            .focusableInNonTouchMode(interactionSource = interactionSource)
+                                            .width(dimens.maxReaderWidth),
+                                )
                             }
+                        }
                         ProvideScaledText(
                             style =
-                                MaterialTheme.typography.bodyLarge.merge(
+                                MaterialTheme.typography.titleMedium.merge(
                                     LinkTextStyle(),
                                 ),
                         ) {
-                            Text(
-                                text = openLabel,
-                                modifier =
-                                    Modifier
-                                        .width(dimens.maxReaderWidth)
-                                        .clickable {
-                                            onEnclosureClick()
-                                        }.clearAndSetSemantics {
-                                            try {
-                                                customActions =
-                                                    listOf(
-                                                        CustomAccessibilityAction(openLabel) {
-                                                            onEnclosureClick()
-                                                            true
-                                                        },
-                                                    )
-                                            } catch (e: Exception) {
-                                                // Observed nullpointer exception when setting customActions
-                                                // No clue why it could be null
-                                                Log.e(
-                                                    LOG_TAG,
-                                                    "Exception in semantics",
-                                                    e,
-                                                )
-                                            }
-                                        },
-                            )
+                            WithBidiDeterminedLayoutDirection(paragraph = feedTitle) {
+                                Text(
+                                    text = feedTitle,
+                                    modifier =
+                                        Modifier
+                                            .width(dimens.maxReaderWidth)
+                                            .clearAndSetSemantics {
+                                                contentDescription = feedTitle
+                                            }.clickable {
+                                                onFeedTitleClick()
+                                            },
+                                )
+                            }
+                        }
+                        if (authorDate != null) {
+                            ProvideScaledText(style = MaterialTheme.typography.titleMedium) {
+                                CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
+                                    WithBidiDeterminedLayoutDirection(paragraph = authorDate) {
+                                        val interactionSource = remember { MutableInteractionSource() }
+                                        Text(
+                                            text = authorDate,
+                                            modifier =
+                                                Modifier
+                                                    .width(dimens.maxReaderWidth)
+                                                    .indication(interactionSource, LocalIndication.current)
+                                                    .focusableInNonTouchMode(interactionSource = interactionSource),
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                        if (readTimeSecs > 0) {
+                            ProvideScaledText(style = MaterialTheme.typography.titleMedium) {
+                                CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
+                                    Row(
+                                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        modifier = Modifier.width(dimens.maxReaderWidth),
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Outlined.Timelapse,
+                                            contentDescription = null,
+                                        )
+                                        val seconds = "%02d".format(readTimeSecs % 60)
+                                        val readTimeText =
+                                            pluralStringResource(
+                                                id = R.plurals.n_minutes,
+                                                count = readTimeSecs / 60,
+                                            ).format(
+                                                "${readTimeSecs / 60}:$seconds",
+                                            )
+                                        WithBidiDeterminedLayoutDirection(paragraph = readTimeText) {
+                                            val interactionSource =
+                                                remember { MutableInteractionSource() }
+                                            Text(
+                                                text = readTimeText,
+                                                modifier =
+                                                    Modifier
+                                                        .weight(1f)
+                                                        .indication(
+                                                            interactionSource,
+                                                            LocalIndication.current,
+                                                        ).focusableInNonTouchMode(interactionSource = interactionSource),
+                                            )
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }
-            }
 
-            if (image != null && shouldShowHeaderImage(showHeaderImage, image, contentImageUrls)) {
-                val imageWidth: Int =
-                    if (image.width?.let { it < 640 } == true) {
-                        // Zero or too small, do not show
-                        -1
-                    } else if (image.width != null) {
-                        image.width ?: Int.MAX_VALUE
-                    } else {
-                        // Enclosures do not have a known width. This will be constrained below.
-                        Int.MAX_VALUE
-                    }
-
-                if (imageWidth > 0) {
+                if (enclosure.present) {
                     offsetCounter++
                     run {
-                        BoxWithConstraints(
-                            contentAlignment = Alignment.Center,
-                            modifier =
-                                Modifier
-                                    .clip(RectangleShape)
-                                    .width(dimens.maxReaderWidth),
-                        ) {
-                            WithTooltipIfNotBlank(tooltip = stringResource(id = R.string.article_image)) {
-                                val maxImageWidth by rememberMaxImageWidth()
-                                val pixelDensity = LocalDensity.current.density
-                                val contentScale =
-                                    remember(pixelDensity) {
-                                        RestrainedCropScaling(pixelDensity)
-                                    }
-                                AsyncImage(
-                                    model =
-                                        ImageRequest
-                                            .Builder(LocalContext.current)
-                                            .data(image.url)
-                                            .scale(Scale.FIT)
-                                            .size(imageWidth.coerceAtMost(maxImageWidth))
-                                            .precision(Precision.INEXACT)
-                                            .build(),
-                                    contentDescription = enclosure.name,
-                                    placeholder =
-                                        rememberTintedVectorPainter(
-                                            Icons.Outlined.Terrain,
-                                        ),
-                                    error = rememberTintedVectorPainter(Icons.Outlined.ErrorOutline),
-                                    contentScale = contentScale,
-                                    alignment = Alignment.Center,
+                        // Image will be shown in block below
+                        if (!enclosure.isImage) {
+                            val openLabel =
+                                if (enclosure.name.isBlank()) {
+                                    stringResource(R.string.open_enclosed_media)
+                                } else {
+                                    stringResource(R.string.open_enclosed_media_file, enclosure.name)
+                                }
+                            ProvideScaledText(
+                                style =
+                                    MaterialTheme.typography.bodyLarge.merge(
+                                        LinkTextStyle(),
+                                    ),
+                            ) {
+                                Text(
+                                    text = openLabel,
                                     modifier =
                                         Modifier
-                                            .fillMaxWidth()
-                                            .run {
-                                                dimens.imageAspectRatioInReader?.let { ratio ->
-                                                    aspectRatio(ratio)
-                                                } ?: this
+                                            .width(dimens.maxReaderWidth)
+                                            .clickable {
+                                                onEnclosureClick()
+                                            }.clearAndSetSemantics {
+                                                try {
+                                                    customActions =
+                                                        listOf(
+                                                            CustomAccessibilityAction(openLabel) {
+                                                                onEnclosureClick()
+                                                                true
+                                                            },
+                                                        )
+                                                } catch (e: Exception) {
+                                                    // Observed nullpointer exception when setting customActions
+                                                    // No clue why it could be null
+                                                    Log.e(
+                                                        LOG_TAG,
+                                                        "Exception in semantics",
+                                                        e,
+                                                    )
+                                                }
                                             },
                                 )
                             }
                         }
                     }
                 }
+
+                if (image != null && shouldShowHeaderImage(showHeaderImage, image, contentImageUrls)) {
+                    val imageWidth: Int =
+                        if (image.width?.let { it < 640 } == true) {
+                            // Zero or too small, do not show
+                            -1
+                        } else if (image.width != null) {
+                            image.width ?: Int.MAX_VALUE
+                        } else {
+                            // Enclosures do not have a known width. This will be constrained below.
+                            Int.MAX_VALUE
+                        }
+
+                    if (imageWidth > 0) {
+                        offsetCounter++
+                        run {
+                            BoxWithConstraints(
+                                contentAlignment = Alignment.Center,
+                                modifier =
+                                    Modifier
+                                        .clip(RectangleShape)
+                                        .width(dimens.maxReaderWidth),
+                            ) {
+                                WithTooltipIfNotBlank(tooltip = stringResource(id = R.string.article_image)) {
+                                    val maxImageWidth by rememberMaxImageWidth()
+                                    val pixelDensity = LocalDensity.current.density
+                                    val contentScale =
+                                        remember(pixelDensity) {
+                                            RestrainedCropScaling(pixelDensity)
+                                        }
+                                    AsyncImage(
+                                        model =
+                                            ImageRequest
+                                                .Builder(LocalContext.current)
+                                                .data(image.url)
+                                                .scale(Scale.FIT)
+                                                .size(imageWidth.coerceAtMost(maxImageWidth))
+                                                .precision(Precision.INEXACT)
+                                                .build(),
+                                        contentDescription = enclosure.name,
+                                        placeholder =
+                                            rememberTintedVectorPainter(
+                                                Icons.Outlined.Terrain,
+                                            ),
+                                        error = rememberTintedVectorPainter(Icons.Outlined.ErrorOutline),
+                                        contentScale = contentScale,
+                                        alignment = Alignment.Center,
+                                        modifier =
+                                            Modifier
+                                                .fillMaxWidth()
+                                                .run {
+                                                    dimens.imageAspectRatioInReader?.let { ratio ->
+                                                        aspectRatio(ratio)
+                                                    } ?: this
+                                                },
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+
+                articleBody(offsetCounter)
+
+                // Bottom spacing
+                Spacer(modifier = Modifier.height(92.dp))
             }
-
-            articleBody(offsetCounter)
-
-            // Bottom spacing
-            Spacer(modifier = Modifier.height(92.dp))
         }
     }
 }


### PR DESCRIPTION
## What does this change?

Restores the scroll position indicator in the article reader. The `LazyColumn` to `Column` rewrite in #1045 (commit 0416165d, which fixed the selected-text crash) dropped the `my.nanihadesuka` scrollbar wrapper added in 65fef39a, so the reader has had no progress indicator since. The scrolling `Column` is now wrapped in `ColumnScrollbar` bound to the same hoisted `articleScrollState`, with the original thumb styling (`ScrollbarSettings.Default.copy(thumbUnselectedColor = MaterialTheme.colorScheme.outlineVariant)`). The `com.github.nanihadesuka:LazyColumnScrollbar` dependency was still declared and bundled, just unused, so no gradle change is needed.

This does not reintroduce the #1045 crash: the plain `Column` with `verticalScroll` stays, the scrollbar is only an overlay around it.

## Checklist

- [x] Ran `./gradlew ktlintFormat` and committed the result (no formatting changes were produced)
- [ ] If the Room schema changed: added a `MIGRATION_N_N+1` in `AppDatabase.kt` (N/A, no schema change)
- [ ] If the Room schema changed: added a migration test in `app/src/androidTest/.../db/room/` (N/A, no schema change)

## Screenshots (if UI change)

The change adds the same scrollbar overlay the reader had before 0416165d; thumb appears on the right edge of the reader pane while scrolling long articles and is absent for articles that fit on screen.

Fixes #1150
