### PR TITLE
fix: exposed missing strings to translations

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/localtranslation/LocalTranslator.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/localtranslation/LocalTranslator.kt
@@ -12,6 +12,7 @@ import android.view.translation.TranslationResponse
 import android.view.translation.TranslationResponseValue
 import android.view.translation.TranslationSpec
 import androidx.annotation.RequiresApi
+import com.nononsenseapps.feeder.R
 import com.nononsenseapps.feeder.model.detectLocaleFromText
 import com.nononsenseapps.feeder.model.hasEnoughTextForLanguageDetection
 import com.nononsenseapps.feeder.model.prepareTextForLanguageDetection
@@ -44,7 +45,7 @@ class LocalTranslator(
         withContext(Dispatchers.IO) {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
                 return@withContext TranslationResult.Error(
-                    content = "Local translation requires Android 12 or newer.",
+                    content = application.getString(R.string.local_translation_requires_android_12),
                 )
             }
 

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/sync/SyncScreen.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/sync/SyncScreen.kt
@@ -615,9 +615,8 @@ fun SyncSetupContent(
                         },
             )
         }
-        // Let this be hard-coded. It should not be localized.
         Text(
-            text = "WARNING! This is a Beta feature. Do an OPML-export of all your feeds before and save as a backup.",
+            text = stringResource(R.string.device_sync_beta_warning),
             style = MaterialTheme.typography.titleMedium,
             modifier = Modifier.fillMaxWidth(),
         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -306,6 +306,7 @@
   <string name="touch_to_play_audio">Touch to play audio</string>
   <string name="title_unread_count" translatable="false">(%1$d)</string>
   <string name="show_title_unread_count">Show unread article count in title</string>
+  <string name="device_sync_beta_warning">WARNING! This is a Beta feature. Do an OPML-export of all your feeds before and save as a backup.</string>
   <string name="unable_to_load_models">Unable to load models.</string>
   <string name="no_models_were_found">No models were found</string>
   <string name="azure_deployment_id">Azure deployment id</string>
@@ -346,6 +347,7 @@
   <string name="preferred_translation_language">Preferred translation language</string>
   <string name="preferred_translation_language_description">Use a language name or code like Spanish, es, French, or fr-CA.</string>
   <string name="preferred_translation_language_fallback">the preferred language</string>
+  <string name="local_translation_requires_android_12">Local translation requires Android 12 or newer.</string>
   <string name="local_translation_setup_pixel">For Local translation on Pixel phones, open Android Settings, then System, Live Translate, Languages, and add %1$s for offline translation. Menu names can vary by Android version; install the source language too if Android asks for it.</string>
   <string name="local_translation_setup_samsung">For Local translation on Samsung devices, open Settings, General management, Language packs, and download %1$s. Some Samsung versions place this under Samsung Keyboard or Translation; install the source language too if Android asks for it.</string>
   <string name="local_translation_setup_generic">For Local translation, open your device Settings app and look for on-device or offline translation language packs under System, General management, Languages, or Translation. Download %1$s and the source languages you read.</string>


### PR DESCRIPTION
## What does this change?

Fixes #1162.

Moves two app-owned English messages into string resources so they can be picked up by translation tooling:

- the device sync beta warning
- the local translation Android 12 requirement message

## Checklist

- [x] Ran `./gradlew ktlintFormat` and committed the result
- [x] If the Room schema changed: added a `MIGRATION_N_N+1` in `AppDatabase.kt` (not applicable; no schema change)
- [x] If the Room schema changed: added a migration test in `app/src/androidTest/.../db/room/` (not applicable; no schema change)

Verification:

- `./gradlew ktlintCheck compileFdroidDebugKotlin`
- `git diff --check`

## Screenshots (if UI change)

Not included. This change exposes existing text to translation resources without changing the UI layout.
