### PR TITLE
feat: added audio player for media attachments

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/FeederApplication.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/FeederApplication.kt
@@ -35,6 +35,7 @@ import com.nononsenseapps.feeder.di.networkModule
 import com.nononsenseapps.feeder.model.AlwaysUseCacheIfPossibleRequestsInterceptor
 import com.nononsenseapps.feeder.model.ForceCacheOnSomeFailuresInterceptor
 import com.nononsenseapps.feeder.model.OneImageRequestPerHostInterceptor
+import com.nononsenseapps.feeder.model.PodcastPlayerStateHolder
 import com.nononsenseapps.feeder.model.RateLimitedInterceptor
 import com.nononsenseapps.feeder.model.TTSStateHolder
 import com.nononsenseapps.feeder.model.TooManyRequestsInterceptor
@@ -69,6 +70,7 @@ class FeederApplication :
     SingletonImageLoader.Factory {
     private val applicationCoroutineScope = ApplicationCoroutineScope()
     private val ttsStateHolder = TTSStateHolder(this, applicationCoroutineScope)
+    private val podcastPlayerStateHolder = PodcastPlayerStateHolder(this, applicationCoroutineScope)
 
     override val di by DI.lazy {
         bind<FilePathProvider>() with
@@ -208,6 +210,7 @@ class FeederApplication :
         bind<ApplicationCoroutineScope>() with instance(applicationCoroutineScope)
         import(networkModule)
         bind<TTSStateHolder>() with instance(ttsStateHolder)
+        bind<PodcastPlayerStateHolder>() with instance(podcastPlayerStateHolder)
         bind<NotificationsWorker>() with singleton { NotificationsWorker(di) }
     }
 
@@ -220,6 +223,7 @@ class FeederApplication :
     override fun onTerminate() {
         applicationCoroutineScope.cancel("Application is being terminated")
         ttsStateHolder.shutdown()
+        podcastPlayerStateHolder.shutdown()
         super.onTerminate()
     }
 

--- a/app/src/main/java/com/nononsenseapps/feeder/model/PodcastPlayerStateHolder.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/PodcastPlayerStateHolder.kt
@@ -1,0 +1,222 @@
+package com.nononsenseapps.feeder.model
+
+import android.app.Application
+import android.media.AudioAttributes
+import android.media.MediaPlayer
+import android.net.Uri
+import androidx.compose.runtime.Immutable
+import com.nononsenseapps.feeder.R
+import com.nononsenseapps.feeder.util.logDebug
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+class PodcastPlayerStateHolder(
+    private val application: Application,
+    private val coroutineScope: CoroutineScope,
+) {
+    private val _playerState = MutableStateFlow(PodcastPlayerState())
+    val playerState: StateFlow<PodcastPlayerState> = _playerState.asStateFlow()
+
+    private var mediaPlayer: MediaPlayer? = null
+    private var progressJob: Job? = null
+
+    fun playLink(link: String) {
+        if (link.isBlank()) {
+            return
+        }
+
+        releaseCurrentPlayer()
+        _playerState.value =
+            PodcastPlayerState(
+                audioUrl = link,
+                isVisible = true,
+                isLoading = true,
+            )
+
+        initializePlayer(link)
+    }
+
+    fun play() {
+        val player = mediaPlayer ?: return
+        player.start()
+        startProgressUpdates()
+        _playerState.update { it.copy(isPlaying = true) }
+    }
+
+    fun pause() {
+        mediaPlayer?.pause()
+        stopProgressUpdates()
+        _playerState.update { it.copy(isPlaying = false) }
+    }
+
+    fun stop() {
+        releaseCurrentPlayer()
+        _playerState.value = PodcastPlayerState()
+    }
+
+    fun seekBy(deltaMillis: Int) {
+        val player = mediaPlayer ?: return
+        val currentState = _playerState.value
+        if (!currentState.canSeek) {
+            return
+        }
+
+        val targetPosition = (player.currentPosition + deltaMillis).coerceIn(0, player.duration.coerceAtLeast(0))
+        player.seekTo(targetPosition)
+        _playerState.update { it.copy(positionMillis = targetPosition) }
+    }
+
+    fun seekTo(positionMillis: Int) {
+        val player = mediaPlayer ?: return
+        val currentState = _playerState.value
+        if (!currentState.canSeek) {
+            return
+        }
+
+        val targetPosition = positionMillis.coerceIn(0, player.duration.coerceAtLeast(0))
+        player.seekTo(targetPosition)
+        _playerState.update { it.copy(positionMillis = targetPosition) }
+    }
+
+    fun shutdown() {
+        releaseCurrentPlayer()
+    }
+
+    private fun initializePlayer(link: String) {
+        coroutineScope.launch {
+            runCatching {
+                MediaPlayer().apply {
+                    setAudioAttributes(
+                        AudioAttributes
+                            .Builder()
+                            .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                            .setUsage(AudioAttributes.USAGE_MEDIA)
+                            .build(),
+                    )
+                    setOnPreparedListener { player ->
+                        player.start()
+                        _playerState.update {
+                            it.copy(
+                                isLoading = false,
+                                isBuffering = false,
+                                isPlaying = true,
+                                canSeek = player.duration > 0,
+                                durationMillis = player.duration.coerceAtLeast(0),
+                                errorMessage = null,
+                            )
+                        }
+                        startProgressUpdates()
+                    }
+                    setOnCompletionListener { player ->
+                        stopProgressUpdates()
+                        _playerState.update {
+                            it.copy(
+                                isPlaying = false,
+                                isBuffering = false,
+                                positionMillis = player.duration.coerceAtLeast(0),
+                            )
+                        }
+                    }
+                    setOnInfoListener { _, what, _ ->
+                        when (what) {
+                            MediaPlayer.MEDIA_INFO_BUFFERING_START -> {
+                                _playerState.update { it.copy(isBuffering = true) }
+                                true
+                            }
+
+                            MediaPlayer.MEDIA_INFO_BUFFERING_END -> {
+                                _playerState.update { it.copy(isBuffering = false) }
+                                true
+                            }
+
+                            else -> false
+                        }
+                    }
+                    setOnErrorListener { _, what, extra ->
+                        logDebug(LOG_TAG, "Podcast playback failed: $what / $extra")
+                        stopProgressUpdates()
+                        _playerState.update {
+                            it.copy(
+                                isLoading = false,
+                                isBuffering = false,
+                                isPlaying = false,
+                                errorMessage = application.getString(R.string.audio_playback_failed),
+                            )
+                        }
+                        true
+                    }
+
+                    setDataSource(application, Uri.parse(link))
+                    prepareAsync()
+                }
+            }.onSuccess { player ->
+                mediaPlayer = player
+            }.onFailure { error ->
+                logDebug(LOG_TAG, "Failed to initialize podcast player: ${error.message}")
+                _playerState.update {
+                    it.copy(
+                        isLoading = false,
+                        isBuffering = false,
+                        isPlaying = false,
+                        errorMessage = application.getString(R.string.audio_playback_failed),
+                    )
+                }
+            }
+        }
+    }
+
+    private fun startProgressUpdates() {
+        progressJob?.cancel()
+        progressJob =
+            coroutineScope.launch {
+                while (isActive) {
+                    val player = mediaPlayer ?: break
+                    _playerState.update {
+                        it.copy(
+                            positionMillis = player.currentPosition.coerceAtLeast(0),
+                            durationMillis = player.duration.coerceAtLeast(0),
+                        )
+                    }
+                    delay(500)
+                }
+            }
+    }
+
+    private fun stopProgressUpdates() {
+        progressJob?.cancel()
+        progressJob = null
+    }
+
+    private fun releaseCurrentPlayer() {
+        stopProgressUpdates()
+        mediaPlayer?.runCatching {
+            stop()
+        }
+        mediaPlayer?.release()
+        mediaPlayer = null
+    }
+
+    companion object {
+        private const val LOG_TAG = "FEEDER_PODCAST"
+    }
+}
+
+@Immutable
+data class PodcastPlayerState(
+    val audioUrl: String = "",
+    val isVisible: Boolean = false,
+    val isLoading: Boolean = false,
+    val isBuffering: Boolean = false,
+    val isPlaying: Boolean = false,
+    val canSeek: Boolean = false,
+    val durationMillis: Int = 0,
+    val positionMillis: Int = 0,
+    val errorMessage: String? = null,
+)

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
@@ -127,6 +127,7 @@ import com.nononsenseapps.feeder.ui.compose.empty.NothingToRead
 import com.nononsenseapps.feeder.ui.compose.feedarticle.FeedListFilterCallback
 import com.nononsenseapps.feeder.ui.compose.feedarticle.FeedScreenViewState
 import com.nononsenseapps.feeder.ui.compose.feedarticle.FeedViewModel
+import com.nononsenseapps.feeder.ui.compose.feedarticle.HideablePodcastPlayer
 import com.nononsenseapps.feeder.ui.compose.feedarticle.TranslatedFeedCards
 import com.nononsenseapps.feeder.ui.compose.feedarticle.onlyUnread
 import com.nononsenseapps.feeder.ui.compose.feedarticle.onlyUnreadAndSaved
@@ -312,6 +313,12 @@ fun FeedScreen(
             ttsOnStop = viewModel::ttsStop,
             ttsOnSkipNext = viewModel::ttsSkipNext,
             ttsOnSelectLanguage = viewModel::ttsOnSelectLanguage,
+            podcastOnPlay = viewModel::podcastPlay,
+            podcastOnPause = viewModel::podcastPause,
+            podcastOnStop = viewModel::podcastStop,
+            podcastOnSeekBack = { viewModel.podcastSeekBy(-10_000) },
+            podcastOnSeekForward = { viewModel.podcastSeekBy(10_000) },
+            podcastOnSeekTo = viewModel::podcastSeekTo,
             onAddFeed = { SearchFeedDestination.navigate(navController) },
             onEditFeed = { feedId ->
                 EditFeedDestination.navigate(navController, feedId)
@@ -519,6 +526,12 @@ fun FeedScreen(
     ttsOnStop: () -> Unit,
     ttsOnSkipNext: () -> Unit,
     ttsOnSelectLanguage: (LocaleOverride) -> Unit,
+    podcastOnPlay: () -> Unit,
+    podcastOnPause: () -> Unit,
+    podcastOnStop: () -> Unit,
+    podcastOnSeekBack: () -> Unit,
+    podcastOnSeekForward: () -> Unit,
+    podcastOnSeekTo: (Int) -> Unit,
     onAddFeed: () -> Unit,
     onEditFeed: (Long) -> Unit,
     onShowEditDialog: () -> Unit,
@@ -585,6 +598,12 @@ fun FeedScreen(
         ttsOnStop = ttsOnStop,
         ttsOnSkipNext = ttsOnSkipNext,
         ttsOnSelectLanguage = ttsOnSelectLanguage,
+        podcastOnPlay = podcastOnPlay,
+        podcastOnPause = podcastOnPause,
+        podcastOnStop = podcastOnStop,
+        podcastOnSeekBack = podcastOnSeekBack,
+        podcastOnSeekForward = podcastOnSeekForward,
+        podcastOnSeekTo = podcastOnSeekTo,
         onDismissDeleteDialog = onDismissDeleteDialog,
         onDismissEditDialog = onDismissEditDialog,
         onRenameTag = onRenameTag,
@@ -1094,6 +1113,12 @@ fun FeedScreen(
     ttsOnStop: () -> Unit,
     ttsOnSkipNext: () -> Unit,
     ttsOnSelectLanguage: (LocaleOverride) -> Unit,
+    podcastOnPlay: () -> Unit,
+    podcastOnPause: () -> Unit,
+    podcastOnStop: () -> Unit,
+    podcastOnSeekBack: () -> Unit,
+    podcastOnSeekForward: () -> Unit,
+    podcastOnSeekTo: (Int) -> Unit,
     onDismissDeleteDialog: () -> Unit,
     onDismissEditDialog: () -> Unit,
     onRenameTag: (String, String) -> Unit,
@@ -1209,21 +1234,34 @@ fun FeedScreen(
             )
         },
         bottomBar = {
-            HideableTTSPlayer(
-                visibleState = bottomBarVisibleState,
-                currentlyPlaying = viewState.isTTSPlaying,
-                onPlay = ttsOnPlay,
-                onPause = ttsOnPause,
-                onStop = ttsOnStop,
-                onSkipNext = ttsOnSkipNext,
-                languages = ImmutableHolder(viewState.ttsLanguages),
-                onSelectLanguage = ttsOnSelectLanguage,
-                floatingActionButton =
-                    when (viewState.showFab) {
-                        true -> floatingActionButton
-                        false -> null
-                    },
-            )
+            if (viewState.podcastPlayerState.isVisible) {
+                HideablePodcastPlayer(
+                    visibleState = bottomBarVisibleState,
+                    viewState = viewState.podcastPlayerState,
+                    onPlay = podcastOnPlay,
+                    onPause = podcastOnPause,
+                    onStop = podcastOnStop,
+                    onSeekBack = podcastOnSeekBack,
+                    onSeekForward = podcastOnSeekForward,
+                    onSeekTo = podcastOnSeekTo,
+                )
+            } else {
+                HideableTTSPlayer(
+                    visibleState = bottomBarVisibleState,
+                    currentlyPlaying = viewState.isTTSPlaying,
+                    onPlay = ttsOnPlay,
+                    onPause = ttsOnPause,
+                    onStop = ttsOnStop,
+                    onSkipNext = ttsOnSkipNext,
+                    languages = ImmutableHolder(viewState.ttsLanguages),
+                    onSelectLanguage = ttsOnSelectLanguage,
+                    floatingActionButton =
+                        when (viewState.showFab) {
+                            true -> floatingActionButton
+                            false -> null
+                        },
+                )
+            }
         },
         floatingActionButton = {
             if (viewState.showFab) {

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleScreen.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleScreen.kt
@@ -182,12 +182,19 @@ fun ArticleScreen(
         onFeedTitleClick = {
             onNavigateToFeed(viewState.articleFeedId)
         },
+        onOpenAudioPlayer = viewModel::openPodcastPlayer,
         onShowToolbarMenu = viewModel::setToolbarMenuVisible,
         ttsOnPlay = viewModel::ttsPlay,
         ttsOnPause = viewModel::ttsPause,
         ttsOnStop = viewModel::ttsStop,
         ttsOnSkipNext = viewModel::ttsSkipNext,
         ttsOnSelectLanguage = viewModel::ttsOnSelectLanguage,
+        podcastOnPlay = viewModel::podcastPlay,
+        podcastOnPause = viewModel::podcastPause,
+        podcastOnStop = viewModel::stopPodcastPlayback,
+        podcastOnSeekBack = { viewModel.podcastSeekBy(-10_000) },
+        podcastOnSeekForward = { viewModel.podcastSeekBy(10_000) },
+        podcastOnSeekTo = viewModel::podcastSeekTo,
         onToggleBookmark = {
             viewModel.setBookmarked(!viewState.isBookmarked)
         },
@@ -216,12 +223,19 @@ fun ArticleScreen(
     onShare: () -> Unit,
     onOpenInCustomTab: () -> Unit,
     onFeedTitleClick: () -> Unit,
+    onOpenAudioPlayer: (url: String) -> Unit,
     onShowToolbarMenu: (Boolean) -> Unit,
     ttsOnPlay: () -> Unit,
     ttsOnPause: () -> Unit,
     ttsOnStop: () -> Unit,
     ttsOnSkipNext: () -> Unit,
     ttsOnSelectLanguage: (LocaleOverride) -> Unit,
+    podcastOnPlay: () -> Unit,
+    podcastOnPause: () -> Unit,
+    podcastOnStop: () -> Unit,
+    podcastOnSeekBack: () -> Unit,
+    podcastOnSeekForward: () -> Unit,
+    podcastOnSeekTo: (Int) -> Unit,
     onToggleBookmark: () -> Unit,
     articleScrollState: ScrollState,
     onNavigateUp: () -> Unit,
@@ -447,16 +461,29 @@ fun ArticleScreen(
             )
         },
         bottomBar = {
-            HideableTTSPlayer(
-                visibleState = bottomBarVisibleState,
-                currentlyPlaying = viewState.isTTSPlaying,
-                onPlay = ttsOnPlay,
-                onPause = ttsOnPause,
-                onStop = ttsOnStop,
-                onSkipNext = ttsOnSkipNext,
-                languages = ImmutableHolder(viewState.ttsLanguages),
-                onSelectLanguage = ttsOnSelectLanguage,
-            )
+            if (viewState.podcastPlayerState.isVisible) {
+                HideablePodcastPlayer(
+                    visibleState = bottomBarVisibleState,
+                    viewState = viewState.podcastPlayerState,
+                    onPlay = podcastOnPlay,
+                    onPause = podcastOnPause,
+                    onStop = podcastOnStop,
+                    onSeekBack = podcastOnSeekBack,
+                    onSeekForward = podcastOnSeekForward,
+                    onSeekTo = podcastOnSeekTo,
+                )
+            } else {
+                HideableTTSPlayer(
+                    visibleState = bottomBarVisibleState,
+                    currentlyPlaying = viewState.isTTSPlaying,
+                    onPlay = ttsOnPlay,
+                    onPause = ttsOnPause,
+                    onStop = ttsOnStop,
+                    onSkipNext = ttsOnSkipNext,
+                    languages = ImmutableHolder(viewState.ttsLanguages),
+                    onSelectLanguage = ttsOnSelectLanguage,
+                )
+            }
         },
     ) { padding ->
         // Box handles the dynamic padding so ArticleContent don't have to recompose on scroll
@@ -471,6 +498,7 @@ fun ArticleScreen(
                 screenType = ScreenType.SINGLE,
                 articleScrollState = articleScrollState,
                 onFeedTitleClick = onFeedTitleClick,
+                onOpenAudioPlayer = onOpenAudioPlayer,
                 onOpenInCustomTab = onOpenInCustomTab,
                 modifier =
                     Modifier
@@ -535,6 +563,7 @@ fun ArticleContent(
     viewState: ArticleScreenViewState,
     screenType: ScreenType,
     onFeedTitleClick: () -> Unit,
+    onOpenAudioPlayer: (url: String) -> Unit,
     onOpenInCustomTab: () -> Unit,
     articleScrollState: ScrollState,
     modifier: Modifier = Modifier,
@@ -554,7 +583,11 @@ fun ArticleContent(
         wordCount = viewState.wordCount,
         onEnclosureClick = {
             if (viewState.enclosure.present) {
-                activityLauncher.openLinkInBrowser(link = viewState.enclosure.link)
+                if (shouldOpenInPodcastPlayer(viewState.enclosure.link, viewState.enclosure)) {
+                    onOpenAudioPlayer(viewState.enclosure.link)
+                } else {
+                    activityLauncher.openLinkInBrowser(link = viewState.enclosure.link)
+                }
             }
         },
         onFeedTitleClick = onFeedTitleClick,
@@ -615,11 +648,15 @@ fun ArticleContent(
                                     }
                                 }
                             } else {
-                                // External link - open in browser/custom tab
-                                activityLauncher.openLink(
-                                    link = link,
-                                    toolbarColor = toolbarColor,
-                                )
+                                if (shouldOpenInPodcastPlayer(link, viewState.enclosure)) {
+                                    onOpenAudioPlayer(link)
+                                } else {
+                                    // External link - open in browser/custom tab
+                                    activityLauncher.openLink(
+                                        link = link,
+                                        toolbarColor = toolbarColor,
+                                    )
+                                }
                             }
                         },
                         onElementPosition = { index, yPosition ->

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleViewModel.kt
@@ -32,6 +32,8 @@ import com.nononsenseapps.feeder.model.NoBody
 import com.nononsenseapps.feeder.model.NoUrl
 import com.nononsenseapps.feeder.model.NotHTML
 import com.nononsenseapps.feeder.model.PlaybackStatus
+import com.nononsenseapps.feeder.model.PodcastPlayerState
+import com.nononsenseapps.feeder.model.PodcastPlayerStateHolder
 import com.nononsenseapps.feeder.model.TTSStateHolder
 import com.nononsenseapps.feeder.model.ThumbnailImage
 import com.nononsenseapps.feeder.model.TranslationManager
@@ -72,6 +74,7 @@ class ArticleViewModel(
 ) : DIAwareViewModel(di) {
     private val repository: Repository by instance()
     private val ttsStateHolder: TTSStateHolder by instance()
+    private val podcastPlayerStateHolder: PodcastPlayerStateHolder by instance()
     private val fullTextParser: FullTextParser by instance()
     private val filePathProvider: FilePathProvider by instance()
     private val openAIApi: OpenAIApi by instance()
@@ -148,6 +151,7 @@ class ArticleViewModel(
             openAiSummary,
             showTranslatedContent,
             articleTranslationState,
+            podcastPlayerStateHolder.playerState,
         ) { params ->
             val article = params[0] as Article?
             val textToDisplay = params[1] as TextToDisplay
@@ -167,6 +171,7 @@ class ArticleViewModel(
             val openAiSummary = params[12] as OpenAISummaryState
             val showTranslated = params[13] as Boolean
             val translationState = params[14] as ArticleTranslationState
+            val podcastPlayerState = params[15] as PodcastPlayerState
             val currentTranslation =
                 (translationState as? ArticleTranslationState.Result)
                     ?.takeIf { it.isFullText == isFullText }
@@ -181,8 +186,9 @@ class ArticleViewModel(
 
             ArticleState(
                 useDetectLanguage = useDetectLanguage,
-                isBottomBarVisible = ttsState != PlaybackStatus.STOPPED,
+                isBottomBarVisible = ttsState != PlaybackStatus.STOPPED || podcastPlayerState.isVisible,
                 isTTSPlaying = ttsState == PlaybackStatus.PLAYING,
+                podcastPlayerState = podcastPlayerState,
                 ttsLanguages = ttsLanguages,
                 articleFeedUrl = article?.feedUrl,
                 articleId = itemId,
@@ -434,6 +440,7 @@ class ArticleViewModel(
     }
 
     fun ttsPlay() {
+        stopPodcastPlayback()
         viewModelScope.launch(Dispatchers.IO) {
             val feedItem = repository.getCurrentArticle() ?: return@launch
             val article = Article(feedItem)
@@ -507,6 +514,35 @@ class ArticleViewModel(
 
     fun ttsStop() {
         ttsStateHolder.stop()
+    }
+
+    fun openPodcastPlayer(link: String) {
+        if (link.isBlank()) {
+            return
+        }
+
+        ttsStop()
+        podcastPlayerStateHolder.playLink(link)
+    }
+
+    fun podcastPlay() {
+        podcastPlayerStateHolder.play()
+    }
+
+    fun podcastPause() {
+        podcastPlayerStateHolder.pause()
+    }
+
+    fun stopPodcastPlayback() {
+        podcastPlayerStateHolder.stop()
+    }
+
+    fun podcastSeekBy(deltaMillis: Int) {
+        podcastPlayerStateHolder.seekBy(deltaMillis)
+    }
+
+    fun podcastSeekTo(positionMillis: Int) {
+        podcastPlayerStateHolder.seekTo(positionMillis)
     }
 
     fun ttsSkipNext() {
@@ -772,6 +808,7 @@ private data class ArticleState(
     override val useDetectLanguage: Boolean = false,
     override val isBottomBarVisible: Boolean = false,
     override val isTTSPlaying: Boolean = false,
+    override val podcastPlayerState: PodcastPlayerState = PodcastPlayerState(),
     override val ttsLanguages: List<Locale> = emptyList(),
     override val articleFeedUrl: String? = null,
     override val articleId: Long = ID_UNSET,
@@ -803,6 +840,7 @@ interface ArticleScreenViewState {
     val useDetectLanguage: Boolean
     val isBottomBarVisible: Boolean
     val isTTSPlaying: Boolean
+    val podcastPlayerState: PodcastPlayerState
     val ttsLanguages: List<Locale>
     val articleFeedUrl: String?
     val articleId: Long

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/FeedViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/FeedViewModel.kt
@@ -24,6 +24,8 @@ import com.nononsenseapps.feeder.db.room.ID_UNSET
 import com.nononsenseapps.feeder.model.FeedUnreadCount
 import com.nononsenseapps.feeder.model.LocaleOverride
 import com.nononsenseapps.feeder.model.PlaybackStatus
+import com.nononsenseapps.feeder.model.PodcastPlayerState
+import com.nononsenseapps.feeder.model.PodcastPlayerStateHolder
 import com.nononsenseapps.feeder.model.TTSStateHolder
 import com.nononsenseapps.feeder.model.TranslationManager
 import com.nononsenseapps.feeder.openai.canUseAsTranslationApi
@@ -56,6 +58,7 @@ class FeedViewModel(
     FeedListFilterCallback {
     private val repository: Repository by instance()
     private val ttsStateHolder: TTSStateHolder by instance()
+    private val podcastPlayerStateHolder: PodcastPlayerStateHolder by instance()
     private val filePathProvider: FilePathProvider by instance()
     private val translationManager: TranslationManager by instance()
 
@@ -466,10 +469,12 @@ class FeedViewModel(
             repository.syncWorkerRunning,
             repository.isOpenDrawerOnFab,
             renameTagDialogVisible,
+            podcastPlayerStateHolder.playerState,
         ) { params: Array<Any> ->
             val haveVisibleFeedItems = (params[7] as Int) > 0
             val currentFeedOrTag = params[13] as FeedOrTag
             val ttsState = params[14] as PlaybackStatus
+            val podcastPlayerState = params[28] as PodcastPlayerState
 
             @Suppress("UNCHECKED_CAST")
             FeedState(
@@ -492,8 +497,8 @@ class FeedViewModel(
                 currentFeedOrTag = currentFeedOrTag,
                 // 14
                 isTTSPlaying = ttsState == PlaybackStatus.PLAYING,
-                // 14
-                isBottomBarVisible = ttsState != PlaybackStatus.STOPPED,
+                podcastPlayerState = podcastPlayerState,
+                isBottomBarVisible = ttsState != PlaybackStatus.STOPPED || podcastPlayerState.isVisible,
                 swipeAsRead = params[15] as SwipeAsRead,
                 ttsLanguages = params[16] as List<Locale>,
                 markAsReadOnScroll = params[17] as Boolean,
@@ -517,6 +522,26 @@ class FeedViewModel(
         ttsStateHolder.stop()
     }
 
+    fun podcastPlay() {
+        podcastPlayerStateHolder.play()
+    }
+
+    fun podcastPause() {
+        podcastPlayerStateHolder.pause()
+    }
+
+    fun podcastStop() {
+        podcastPlayerStateHolder.stop()
+    }
+
+    fun podcastSeekBy(deltaMillis: Int) {
+        podcastPlayerStateHolder.seekBy(deltaMillis)
+    }
+
+    fun podcastSeekTo(positionMillis: Int) {
+        podcastPlayerStateHolder.seekTo(positionMillis)
+    }
+
     fun ttsPause() {
         ttsStateHolder.pause()
     }
@@ -530,6 +555,7 @@ class FeedViewModel(
     }
 
     fun ttsPlay() {
+        podcastPlayerStateHolder.stop()
         viewModelScope.launch(Dispatchers.IO) {
             val article =
                 repository.getCurrentArticle()
@@ -617,6 +643,7 @@ data class FeedState(
     override val expandedTags: Set<String> = emptySet(),
     override val isBottomBarVisible: Boolean = false,
     override val isTTSPlaying: Boolean = false,
+    override val podcastPlayerState: PodcastPlayerState = PodcastPlayerState(),
     override val ttsLanguages: List<Locale> = emptyList(),
     override val showToolbarMenu: Boolean = false,
     override val showDeleteDialog: Boolean = false,
@@ -651,6 +678,7 @@ interface FeedScreenViewState {
     val expandedTags: Set<String>
     val isBottomBarVisible: Boolean
     val isTTSPlaying: Boolean
+    val podcastPlayerState: PodcastPlayerState
     val ttsLanguages: List<Locale>
     val showToolbarMenu: Boolean
     val showDeleteDialog: Boolean

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/PodcastPlayerBar.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/PodcastPlayerBar.kt
@@ -1,0 +1,220 @@
+package com.nononsenseapps.feeder.ui.compose.feedarticle
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Forward10
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Replay10
+import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.surfaceColorAtElevation
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.nononsenseapps.feeder.R
+import com.nononsenseapps.feeder.model.PodcastPlayerState
+import com.nononsenseapps.feeder.ui.compose.components.PaddedBottomAppBar
+import com.nononsenseapps.feeder.ui.compose.feed.PlainTooltipBox
+
+@Composable
+fun HideablePodcastPlayer(
+    visibleState: MutableTransitionState<Boolean>,
+    viewState: PodcastPlayerState,
+    onPlay: () -> Unit,
+    onPause: () -> Unit,
+    onStop: () -> Unit,
+    onSeekBack: () -> Unit,
+    onSeekForward: () -> Unit,
+    onSeekTo: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(
+        modifier = modifier,
+        visibleState = visibleState,
+        enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(256)),
+        exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(256)),
+    ) {
+        PodcastPlayerBar(
+            viewState = viewState,
+            onPlay = onPlay,
+            onPause = onPause,
+            onStop = onStop,
+            onSeekBack = onSeekBack,
+            onSeekForward = onSeekForward,
+            onSeekTo = onSeekTo,
+        )
+    }
+}
+
+@Composable
+fun PodcastPlayerBar(
+    viewState: PodcastPlayerState,
+    onPlay: () -> Unit,
+    onPause: () -> Unit,
+    onStop: () -> Unit,
+    onSeekBack: () -> Unit,
+    onSeekForward: () -> Unit,
+    onSeekTo: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var sliderPosition by remember(viewState.audioUrl) { mutableFloatStateOf(0f) }
+    var isDragging by remember(viewState.audioUrl) { mutableStateOf(false) }
+    val containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(3.dp)
+
+    LaunchedEffect(viewState.positionMillis, viewState.audioUrl, isDragging) {
+        if (!isDragging) {
+            sliderPosition = viewState.positionMillis.toFloat()
+        }
+    }
+
+    Surface(
+        modifier = modifier,
+        color = containerColor,
+        tonalElevation = 0.dp,
+    ) {
+        Column {
+            if (viewState.isLoading || viewState.isBuffering) {
+                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+            }
+
+            if (viewState.errorMessage == null) {
+                Slider(
+                    value = sliderPosition.coerceIn(0f, viewState.durationMillis.toFloat().coerceAtLeast(0f)),
+                    onValueChange = {
+                        isDragging = true
+                        sliderPosition = it
+                    },
+                    onValueChangeFinished = {
+                        isDragging = false
+                        onSeekTo(sliderPosition.toInt())
+                    },
+                    valueRange = 0f..viewState.durationMillis.toFloat().coerceAtLeast(0f),
+                    enabled = viewState.canSeek,
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(start = 12.dp, end = 12.dp, top = 8.dp),
+                )
+
+                Row(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
+                ) {
+                    Text(
+                        text = formatPodcastDuration(viewState.positionMillis),
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                    Spacer(modifier = Modifier.weight(1f))
+                    Text(
+                        text = formatPodcastDuration(viewState.durationMillis),
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+            } else {
+                Text(
+                    text = viewState.errorMessage,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+            }
+
+            PaddedBottomAppBar(
+                containerColor = containerColor,
+                tonalElevation = 0.dp,
+                actions = {
+                    PlainTooltipBox(tooltip = { Text(stringResource(R.string.stop_audio)) }) {
+                        IconButton(onClick = onStop) {
+                            Icon(
+                                Icons.Default.Stop,
+                                contentDescription = stringResource(R.string.stop_audio),
+                            )
+                        }
+                    }
+                    Crossfade(targetState = viewState.isPlaying) { playing ->
+                        if (playing) {
+                            PlainTooltipBox(tooltip = { Text(stringResource(R.string.pause_audio)) }) {
+                                IconButton(onClick = onPause) {
+                                    Icon(
+                                        Icons.Default.Pause,
+                                        contentDescription = stringResource(R.string.pause_audio),
+                                    )
+                                }
+                            }
+                        } else {
+                            PlainTooltipBox(tooltip = { Text(stringResource(R.string.play_audio)) }) {
+                                IconButton(onClick = onPlay) {
+                                    Icon(
+                                        Icons.Default.PlayArrow,
+                                        contentDescription = stringResource(R.string.play_audio),
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    PlainTooltipBox(tooltip = { Text(stringResource(R.string.seek_back_10_seconds)) }) {
+                        IconButton(
+                            onClick = onSeekBack,
+                            enabled = viewState.canSeek,
+                        ) {
+                            Icon(
+                                Icons.Default.Replay10,
+                                contentDescription = stringResource(R.string.seek_back_10_seconds),
+                            )
+                        }
+                    }
+                    PlainTooltipBox(tooltip = { Text(stringResource(R.string.seek_forward_10_seconds)) }) {
+                        IconButton(
+                            onClick = onSeekForward,
+                            enabled = viewState.canSeek,
+                        ) {
+                            Icon(
+                                Icons.Default.Forward10,
+                                contentDescription = stringResource(R.string.seek_forward_10_seconds),
+                            )
+                        }
+                    }
+                },
+            )
+        }
+    }
+}
+
+private fun formatPodcastDuration(totalMillis: Int): String {
+    val totalSeconds = (totalMillis / 1000).coerceAtLeast(0)
+    val hours = totalSeconds / 3600
+    val minutes = (totalSeconds % 3600) / 60
+    val seconds = totalSeconds % 60
+
+    return if (hours > 0) {
+        "%d:%02d:%02d".format(hours, minutes, seconds)
+    } else {
+        "%d:%02d".format(minutes, seconds)
+    }
+}

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/PodcastPlayerLinks.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/PodcastPlayerLinks.kt
@@ -1,0 +1,61 @@
+package com.nononsenseapps.feeder.ui.compose.feedarticle
+
+import com.nononsenseapps.feeder.archmodel.Enclosure
+import java.net.URLDecoder
+
+private val AUDIO_FILE_EXTENSIONS =
+    setOf(
+        "aac",
+        "flac",
+        "m4a",
+        "m4b",
+        "mp3",
+        "mp4",
+        "oga",
+        "ogg",
+        "opus",
+        "wav",
+        "weba",
+    )
+
+fun shouldOpenInPodcastPlayer(
+    link: String,
+    enclosure: Enclosure,
+): Boolean {
+    if (link.isBlank() || link.startsWith("#")) {
+        return false
+    }
+
+    if (link == enclosure.link && enclosure.type.startsWith("audio/")) {
+        return true
+    }
+
+    val path = lastPathSegment(link).lowercase()
+    val extension = path.substringAfterLast('.', missingDelimiterValue = "")
+
+    return extension in AUDIO_FILE_EXTENSIONS
+}
+
+fun audioTitleFromLink(
+    link: String,
+    fallback: String = "",
+): String {
+    val decoded = decodeUrlComponent(lastPathSegment(link)).trim()
+
+    return when {
+        decoded.isNotBlank() -> decoded
+        fallback.isNotBlank() -> fallback
+        else -> link
+    }
+}
+
+private fun lastPathSegment(link: String): String =
+    link
+        .substringBefore('#')
+        .substringBefore('?')
+        .substringAfterLast('/', "")
+
+private fun decodeUrlComponent(value: String): String =
+    runCatching {
+        URLDecoder.decode(value, "UTF-8")
+    }.getOrDefault(value)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,12 @@
   <string name="open_in_browser">Open in web browser</string>
   <string name="open_enclosed_media">Open enclosed media</string>
   <string name="open_enclosed_media_file">Open %1$s</string>
+  <string name="audio_playback_failed">Unable to play this audio file</string>
+  <string name="play_audio">Play audio</string>
+  <string name="pause_audio">Pause audio</string>
+  <string name="stop_audio">Stop audio</string>
+  <string name="seek_back_10_seconds">Seek back 10 seconds</string>
+  <string name="seek_forward_10_seconds">Seek forward 10 seconds</string>
   <string name="read_article">Read aloud</string>
   <string name="text_to_speech">Text to speech</string>
   <string name="pause_reading">Pause reading</string>

--- a/app/src/test/java/com/nononsenseapps/feeder/ui/compose/feedarticle/PodcastPlayerLinksTest.kt
+++ b/app/src/test/java/com/nononsenseapps/feeder/ui/compose/feedarticle/PodcastPlayerLinksTest.kt
@@ -1,0 +1,41 @@
+package com.nononsenseapps.feeder.ui.compose.feedarticle
+
+import com.nononsenseapps.feeder.archmodel.Enclosure
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PodcastPlayerLinksTest {
+    @Test
+    fun detectedAudioLinksByExtension() {
+        assertTrue(shouldOpenInPodcastPlayer("https://example.com/episode.mp3?source=rss", Enclosure()))
+        assertTrue(shouldOpenInPodcastPlayer("https://example.com/episode.m4a", Enclosure()))
+    }
+
+    @Test
+    fun detectedAudioLinksByEnclosureMimeType() {
+        val enclosure =
+            Enclosure(
+                present = true,
+                link = "https://example.com/download",
+                type = "audio/mpeg",
+            )
+
+        assertTrue(shouldOpenInPodcastPlayer(enclosure.link, enclosure))
+    }
+
+    @Test
+    fun ignoredNonAudioLinks() {
+        assertFalse(shouldOpenInPodcastPlayer("https://example.com/article", Enclosure()))
+        assertFalse(shouldOpenInPodcastPlayer("#chapter-2", Enclosure()))
+    }
+
+    @Test
+    fun derivedAudioTitleFromLink() {
+        assertEquals(
+            "Coding Blocks Episode 1.mp3",
+            audioTitleFromLink("https://example.com/Coding%20Blocks%20Episode%201.mp3"),
+        )
+    }
+}


### PR DESCRIPTION
## What does this change?

This PR adds an in-app audio player for audio enclosure links.

Previously, tapping podcast/audio links from an article would hand off playback to an external app or browser. With this change, Feeder now opens those links in an in app bottom player that matches the existing "Read Aloud" UX more closely.

This addresses a long standing feature request: https://github.com/spacecowboy/Feeder/issues/690
> For now, I added the player without any consultation about UI/UX behavior with the @spacecowboy  but I'm open to ideas for making it better

- Added podcast/audio link detection for article links and enclosures
- Added an in-app bottom audio player with:
  - Stop
  - Play / Pause
  - Seek back 10 seconds
  - Seek forward 10 seconds
  - Seek bar with elapsed / total time
- Kept playback app-scoped so it survives leaving the article screen
- Rendered the same player from both the article screen and the feed screen so back navigation behaves consistently with Read Aloud
- Kept non-audio links on the existing external-link path
- Did not add any new dependencies
- Did not require any storage permissions (The player is stream-first and does not require saving the full file to disk)

> This PR does not add background media notifications

## Checklist

- [x] Ran `./gradlew ktlintFormat` and committed the result
- [ ] If the Room schema changed: added a `MIGRATION_N_N+1` in `AppDatabase.kt`
- [ ] If the Room schema changed: added a migration test in `app/src/androidTest/.../db/room/`

## Screenshots (if UI change)

<img width="540" height="1200" alt="changed ui screenshot, with player open" src="https://github.com/user-attachments/assets/eb9f78d3-6c65-43a0-bf11-1360d1c17589" />


> Following screen recordings are without audio, because I was unclear about the resulting copyright effects

### Before

https://github.com/user-attachments/assets/1cb80396-eb61-4a04-b23b-3e81ac60fc26

### After

https://github.com/user-attachments/assets/a602d799-0e38-47ef-9fbb-e6bcc06e244b