### PR TITLE
feat: added button for renaming tags

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/archmodel/FeedStore.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/archmodel/FeedStore.kt
@@ -53,6 +53,13 @@ class FeedStore(
 
     suspend fun getDisplayTitle(feedId: Long): String? = feedDao.getFeedTitle(feedId)?.displayTitle
 
+    suspend fun renameTag(
+        oldTag: String,
+        newTag: String,
+    ) {
+        feedDao.renameTag(oldTag, newTag)
+    }
+
     suspend fun deleteFeeds(feedIds: List<Long>) {
         feedDao.deleteFeeds(feedIds)
     }

--- a/app/src/main/java/com/nononsenseapps/feeder/archmodel/Repository.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/archmodel/Repository.kt
@@ -141,6 +141,17 @@ class Repository(
         settingsStore.setCurrentWidgetFeedAndTag(feedId, tag)
     }
 
+    suspend fun renameTag(
+        oldTag: String,
+        newTag: String,
+    ) {
+        feedStore.renameTag(oldTag, newTag)
+        val (currentFeedId, currentTag) = currentFeedAndTag.value
+        if (currentFeedId == ID_UNSET && currentTag == oldTag) {
+            setCurrentFeedAndTag(ID_UNSET, newTag)
+        }
+    }
+
     val isArticleOpen: StateFlow<Boolean> = settingsStore.isArticleOpen
 
     fun setIsArticleOpen(open: Boolean) {

--- a/app/src/main/java/com/nononsenseapps/feeder/db/room/FeedDao.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/db/room/FeedDao.kt
@@ -174,6 +174,12 @@ interface FeedDao {
         notify: Boolean,
     )
 
+    @Query("UPDATE feeds SET tag = :newTag WHERE tag IS :oldTag")
+    suspend fun renameTag(
+        oldTag: String,
+        newTag: String,
+    )
+
     @Query("UPDATE feeds SET notify = :notify")
     suspend fun setAllNotify(notify: Boolean)
 

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/dialog/RenameTagDialog.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/dialog/RenameTagDialog.kt
@@ -1,0 +1,57 @@
+package com.nononsenseapps.feeder.ui.compose.dialog
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.nononsenseapps.feeder.R
+
+@Composable
+fun RenameTagDialog(
+    currentTagName: String,
+    onDismiss: () -> Unit,
+    onRename: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var tagName by rememberSaveable { mutableStateOf(currentTagName) }
+
+    AlertDialog(
+        modifier = modifier,
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            Button(
+                onClick = {
+                    onRename(tagName)
+                    onDismiss()
+                },
+                enabled = tagName.isNotBlank() && tagName != currentTagName,
+            ) {
+                Text(text = stringResource(id = android.R.string.ok))
+            }
+        },
+        dismissButton = {
+            Button(onClick = onDismiss) {
+                Text(text = stringResource(id = android.R.string.cancel))
+            }
+        },
+        title = {
+            Text(text = stringResource(id = R.string.rename_tag))
+        },
+        text = {
+            OutlinedTextField(
+                value = tagName,
+                onValueChange = { tagName = it },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        },
+    )
+}

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
@@ -122,6 +122,7 @@ import com.nononsenseapps.feeder.model.opml.importOpml
 import com.nononsenseapps.feeder.ui.compose.components.safeSemantics
 import com.nononsenseapps.feeder.ui.compose.deletefeed.DeletableFeed
 import com.nononsenseapps.feeder.ui.compose.deletefeed.DeleteFeedDialog
+import com.nononsenseapps.feeder.ui.compose.dialog.RenameTagDialog
 import com.nononsenseapps.feeder.ui.compose.empty.NothingToRead
 import com.nononsenseapps.feeder.ui.compose.feedarticle.FeedListFilterCallback
 import com.nononsenseapps.feeder.ui.compose.feedarticle.FeedScreenViewState
@@ -324,11 +325,20 @@ fun FeedScreen(
             onDeleteFeeds = { feedIds ->
                 viewModel.deleteFeeds(feedIds.toList())
             },
+            onRenameTag = { oldTag, newTag ->
+                viewModel.renameTag(oldTag, newTag)
+            },
             onShowDeleteDialog = {
                 viewModel.setShowDeleteDialog(true)
             },
             onDismissDeleteDialog = {
                 viewModel.setShowDeleteDialog(false)
+            },
+            onShowRenameTagDialog = {
+                viewModel.setShowRenameTagDialog(true)
+            },
+            onDismissRenameTagDialog = {
+                viewModel.setShowRenameTagDialog(false)
             },
             onSettings = {
                 SettingsDestination.navigate(navController)
@@ -516,6 +526,9 @@ fun FeedScreen(
     onDeleteFeeds: (Iterable<Long>) -> Unit,
     onShowDeleteDialog: () -> Unit,
     onDismissDeleteDialog: () -> Unit,
+    onRenameTag: (String, String) -> Unit,
+    onShowRenameTagDialog: () -> Unit,
+    onDismissRenameTagDialog: () -> Unit,
     onSettings: () -> Unit,
     onImport: () -> Unit,
     onExportOPML: () -> Unit,
@@ -574,6 +587,9 @@ fun FeedScreen(
         ttsOnSelectLanguage = ttsOnSelectLanguage,
         onDismissDeleteDialog = onDismissDeleteDialog,
         onDismissEditDialog = onDismissEditDialog,
+        onRenameTag = onRenameTag,
+        onShowRenameTagDialog = onShowRenameTagDialog,
+        onDismissRenameTagDialog = onDismissRenameTagDialog,
         onDelete = onDeleteFeeds,
         onEditFeed = onEditFeed,
         toolbarActions = {
@@ -881,6 +897,24 @@ fun FeedScreen(
                                     Text(stringResource(id = R.string.delete_feed))
                                 },
                             )
+                            if (viewState.feedScreenTitle.type == FeedType.TAG && !viewState.currentFeedOrTag.isFeed) {
+                                HorizontalDivider()
+                                DropdownMenuItem(
+                                    onClick = {
+                                        onShowToolbarMenu(false)
+                                        onShowRenameTagDialog()
+                                    },
+                                    leadingIcon = {
+                                        Icon(
+                                            Icons.Default.Edit,
+                                            contentDescription = null,
+                                        )
+                                    },
+                                    text = {
+                                        Text(stringResource(id = R.string.rename_tag))
+                                    },
+                                )
+                            }
                             HorizontalDivider()
                             DropdownMenuItem(
                                 onClick = {
@@ -1062,6 +1096,9 @@ fun FeedScreen(
     ttsOnSelectLanguage: (LocaleOverride) -> Unit,
     onDismissDeleteDialog: () -> Unit,
     onDismissEditDialog: () -> Unit,
+    onRenameTag: (String, String) -> Unit,
+    onShowRenameTagDialog: () -> Unit,
+    onDismissRenameTagDialog: () -> Unit,
     onDelete: (Iterable<Long>) -> Unit,
     onEditFeed: (Long) -> Unit,
     toolbarActions: @Composable (RowScope.() -> Unit),
@@ -1251,6 +1288,15 @@ fun FeedScreen(
                     ),
                 onDismiss = onDismissEditDialog,
                 onEdit = onEditFeed,
+            )
+        }
+        if (viewState.showRenameTagDialog) {
+            RenameTagDialog(
+                currentTagName = viewState.feedScreenTitle.title ?: "",
+                onDismiss = onDismissRenameTagDialog,
+                onRename = { newName ->
+                    onRenameTag(viewState.feedScreenTitle.title ?: "", newName)
+                },
             )
         }
     }

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/FeedViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/FeedViewModel.kt
@@ -120,6 +120,13 @@ class FeedViewModel(
             repository.deleteFeeds(feedIds)
         }
 
+    fun renameTag(
+        oldTag: String,
+        newTag: String,
+    ) = applicationCoroutineScope.launch {
+        // TODO: implement tag renaming in repository
+    }
+
     fun markAllAsRead() =
         applicationCoroutineScope.launch {
             val (feedId, feedTag) = repository.currentFeedAndTag.value
@@ -349,6 +356,12 @@ class FeedViewModel(
         deleteDialogVisible.update { visible }
     }
 
+    private val renameTagDialogVisible = MutableStateFlow(false)
+
+    fun setShowRenameTagDialog(visible: Boolean) {
+        renameTagDialogVisible.update { visible }
+    }
+
     private fun setCurrentArticle(itemId: Long) {
         repository.setCurrentArticle(itemId)
         repository.setIsArticleOpen(true)
@@ -452,6 +465,7 @@ class FeedViewModel(
             repository.showTitleUnreadCount,
             repository.syncWorkerRunning,
             repository.isOpenDrawerOnFab,
+            renameTagDialogVisible,
         ) { params: Array<Any> ->
             val haveVisibleFeedItems = (params[7] as Int) > 0
             val currentFeedOrTag = params[13] as FeedOrTag
@@ -471,6 +485,7 @@ class FeedViewModel(
                 feedScreenTitle = params[8] as ScreenTitle,
                 showEditDialog = params[9] as Boolean,
                 showDeleteDialog = params[10] as Boolean,
+                showRenameTagDialog = params[28] as Boolean,
                 visibleFeeds = params[11] as List<FeedTitle>,
                 isArticleOpen = params[12] as Boolean,
                 // 13
@@ -606,6 +621,7 @@ data class FeedState(
     override val showToolbarMenu: Boolean = false,
     override val showDeleteDialog: Boolean = false,
     override val showEditDialog: Boolean = false,
+    override val showRenameTagDialog: Boolean = false,
     // Defaults to true so empty screen doesn't appear before load
     override val haveVisibleFeedItems: Boolean = true,
     override val swipeAsRead: SwipeAsRead = SwipeAsRead.ONLY_FROM_END,
@@ -639,6 +655,7 @@ interface FeedScreenViewState {
     val showToolbarMenu: Boolean
     val showDeleteDialog: Boolean
     val showEditDialog: Boolean
+    val showRenameTagDialog: Boolean
     val haveVisibleFeedItems: Boolean
     val swipeAsRead: SwipeAsRead
     val markAsReadOnScroll: Boolean

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/FeedViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/FeedViewModel.kt
@@ -124,7 +124,7 @@ class FeedViewModel(
         oldTag: String,
         newTag: String,
     ) = applicationCoroutineScope.launch {
-        // TODO: implement tag renaming in repository
+        repository.renameTag(oldTag, newTag)
     }
 
     fun markAllAsRead() =

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
   <string name="mark_all_as_read">Mark all as read</string>
   <string name="edit_feed">Edit feed</string>
   <string name="delete_feed">Delete feed</string>
+  <string name="rename_tag">Rename tag</string>
   <string name="show_all_items">Show all items</string>
   <string name="show_unread_items">Show unread items</string>
   <string name="new_items_available">New items available</string>

--- a/app/src/test/java/com/nononsenseapps/feeder/archmodel/FeedStoreTest.kt
+++ b/app/src/test/java/com/nononsenseapps/feeder/archmodel/FeedStoreTest.kt
@@ -66,6 +66,17 @@ class FeedStoreTest : DIAware {
     }
 
     @Test
+    fun renameTag() {
+        runBlocking {
+            store.renameTag("oldTag", "newTag")
+        }
+
+        coVerify {
+            dao.renameTag("oldTag", "newTag")
+        }
+    }
+
+    @Test
     fun deleteFeeds() {
         runBlocking {
             store.deleteFeeds(listOf(3L, 5L))

--- a/app/src/test/java/com/nononsenseapps/feeder/archmodel/RepositoryTest.kt
+++ b/app/src/test/java/com/nononsenseapps/feeder/archmodel/RepositoryTest.kt
@@ -187,6 +187,36 @@ class RepositoryTest : DIAware {
     }
 
     @Test
+    fun renameTagNotCurrentTag() {
+        every { settingsStore.currentFeedAndTag } returns MutableStateFlow(5L to "anotherTag")
+
+        runBlocking {
+            repository.renameTag("oldTag", "newTag")
+        }
+
+        coVerify {
+            feedStore.renameTag("oldTag", "newTag")
+        }
+        verify(exactly = 0) {
+            repository.setCurrentFeedAndTag(any(), any())
+        }
+    }
+
+    @Test
+    fun renameTagIsCurrentTag() {
+        every { settingsStore.currentFeedAndTag } returns MutableStateFlow(ID_UNSET to "oldTag")
+
+        runBlocking {
+            repository.renameTag("oldTag", "newTag")
+        }
+
+        coVerify {
+            feedStore.renameTag("oldTag", "newTag")
+            repository.setCurrentFeedAndTag(ID_UNSET, "newTag")
+        }
+    }
+
+    @Test
     fun getTextToDisplayForItem() {
         coEvery { feedItemStore.getFullTextByDefault(5L) } returns true
         coEvery { feedItemStore.getFullTextByDefault(6L) } returns false


### PR DESCRIPTION
## What does this change?

This PR implements a feature to rename existing tags to all correlated feeds.

Previously, there was no direct way to modify a tag's name without modifying it in every single feed. This change introduces a contextual "Rename Tag" dialog that updates the tag string across all associated feeds in the local database, ensuring proper state propagation throughout the architecture. The button positioned in the menu only appears when user is viewing a tag, not a feed.

This addresses the requested feature and closes the corresponding issue. (Closes #907)

- Added a custom `RenameTagDialog` Composable component to handle user text input and validation.
- Added a rename button in `FeedScreen` that contextually appears when the user is inside a specific tag view.
- Updated `FeedDao` with a targeted SQL `UPDATE` query to modify the tag column for matching feeds.
- Implemented the `renameTag` execution flow across `FeedStore`, `Repository`, and `FeedViewModel`.
- Added defensive state handling in `Repository`: if the user renames the tag they are currently viewing, the app automatically and seamlessly transitions the active view to the new tag name.
- Added unit tests covering both execution paths (current tag vs. different tag) in `FeedStoreTest` and `RepositoryTest`.
- Did not change the Room database schema (only added a query), so no migration was required.

## Checklist

- [x] Ran `./gradlew ktlintFormat` and committed the result
- [ ] If the Room schema changed: added a `MIGRATION_N_N+1` in `AppDatabase.kt` (N/A - No schema changes)
- [ ] If the Room schema changed: added a migration test in `app/src/androidTest/.../db/room/` (N/A)

## Screenshots (if UI change)

### Before
<img width="270" height="600" alt="FeederD-BEFORE" src="https://github.com/user-attachments/assets/47fb2211-3680-474a-ad3a-6b9ac7dbf2b3" />


### After
<img width="270" height="600" alt="FeederD-AFTER" src="https://github.com/user-attachments/assets/903fec0e-856b-4bf2-89d5-b27f355e999d" />

> *Note: Adding a 11th item to the dropdown menu might (like in my case) cause Android to automatically shift the menu position upward on some screen resolutions to prevent it from clipping at the bottom.*

Fixes #907 
