### PR TITLE
fix: honored custom tab preference in notifications

### DIFF
--- a/app/src/androidTest/java/com/nononsenseapps/feeder/model/RssNotificationsKtTest.kt
+++ b/app/src/androidTest/java/com/nononsenseapps/feeder/model/RssNotificationsKtTest.kt
@@ -3,8 +3,12 @@ package com.nononsenseapps.feeder.model
 import android.content.Intent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
+import com.nononsenseapps.feeder.archmodel.ItemOpener
 import com.nononsenseapps.feeder.db.COL_LINK
 import com.nononsenseapps.feeder.db.room.FeedItem
+import com.nononsenseapps.feeder.ui.MainActivity
+import com.nononsenseapps.feeder.ui.OpenLinkInDefaultActivity
+import com.nononsenseapps.feeder.util.DEEP_LINK_BASE_URI
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -14,6 +18,59 @@ import kotlin.test.assertNull
 
 @RunWith(AndroidJUnit4::class)
 class RssNotificationsKtTest {
+    @Test
+    fun readerContentIntentPointsToArticle() {
+        val intent = articleNotificationIntent(ItemOpener.READER)
+
+        assertEquals(MainActivity::class.java.name, intent.component?.className)
+        assertEquals(Intent.ACTION_VIEW, intent.action)
+        assertEquals("$DEEP_LINK_BASE_URI/article/5", intent.dataString)
+    }
+
+    @Test
+    fun defaultBrowserContentIntentPointsToProxy() {
+        val intent = articleNotificationIntent(ItemOpener.DEFAULT_BROWSER)
+
+        assertEquals(OpenLinkInDefaultActivity::class.java.name, intent.component?.className)
+        assertEquals(Intent.ACTION_VIEW, intent.action)
+        assertEquals("http://foo", intent.data?.getQueryParameter(COL_LINK))
+    }
+
+    @Test
+    fun customTabContentIntentPointsToProxy() {
+        val intent = articleNotificationIntent(ItemOpener.CUSTOM_TAB)
+
+        assertEquals(OpenLinkInDefaultActivity::class.java.name, intent.component?.className)
+        assertEquals(ACTION_OPEN_IN_CUSTOM_TAB, intent.action)
+        assertEquals("http://foo", intent.data?.getQueryParameter(COL_LINK))
+    }
+
+    @Test
+    fun customTabContentIntentDoesNotCollideWithBrowserAction() {
+        val customTabIntent = articleNotificationIntent(ItemOpener.CUSTOM_TAB)
+        val browserActionIntent =
+            getOpenInDefaultActivityIntent(
+                getInstrumentation().context,
+                5,
+                link = "http://foo",
+            )
+
+        assertFalse(
+            customTabIntent.filterEquals(browserActionIntent),
+            message = "custom-tab content intent should not be considered equal to browser action intent",
+        )
+    }
+
+    @Test
+    fun missingLinkFallsBackToReader() {
+        for (articleOpener in ItemOpener.entries) {
+            val intent = articleNotificationIntent(articleOpener, link = null)
+
+            assertEquals(MainActivity::class.java.name, intent.component?.className)
+            assertEquals("$DEEP_LINK_BASE_URI/article/5", intent.dataString)
+        }
+    }
+
     @Test
     fun openInBrowserIntentPointsToActivityWithIdAndLink() {
         val intent: Intent = getOpenInDefaultActivityIntent(getInstrumentation().context, 99, "http://foo")
@@ -78,4 +135,15 @@ class RssNotificationsKtTest {
             message = "Expected a null query parameter",
         )
     }
+
+    private fun articleNotificationIntent(
+        articleOpener: ItemOpener,
+        link: String? = "http://foo",
+    ): Intent =
+        getArticleNotificationIntent(
+            context = getInstrumentation().context,
+            feedItemId = 5,
+            link = link,
+            articleOpener = articleOpener,
+        )
 }

--- a/app/src/main/java/com/nononsenseapps/feeder/model/RssNotifications.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/RssNotifications.kt
@@ -49,6 +49,7 @@ import org.kodein.di.instance
 const val SUMMARY_NOTIFICATION_ID = 2_147_483_646
 private const val CHANNEL_ID = "feederNotifications"
 private const val ARTICLE_NOTIFICATION_GROUP = "com.nononsenseapps.feeder.ARTICLE"
+internal const val ACTION_OPEN_IN_CUSTOM_TAB = "com.nononsenseapps.feeder.OPEN_IN_CUSTOM_TAB"
 
 private const val LOG_TAG = "FEEDER_NOTIFY"
 
@@ -140,6 +141,7 @@ private suspend fun singleNotification(
 ): Notification {
     val di by closestDI(context)
     val repository: Repository by di.instance()
+    val articleOpener = repository.getArticleOpener(item.id)
 
     val style = NotificationCompat.BigTextStyle()
     val title = item.plainTitle
@@ -148,15 +150,7 @@ private suspend fun singleNotification(
     style.bigText(text)
     style.setBigContentTitle(title)
 
-    val contentIntent =
-        Intent(
-            Intent.ACTION_VIEW,
-            "$DEEP_LINK_BASE_URI/article/${item.id}".toUri(),
-            context,
-            MainActivity::class.java,
-        ).apply {
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        }
+    val contentIntent = getArticleNotificationIntent(context, item.id, item.link, articleOpener)
 
     val pendingIntent =
         PendingIntent.getActivity(
@@ -171,6 +165,7 @@ private suspend fun singleNotification(
     builder
         .setContentText(text)
         .setContentTitle(title)
+        .setContentIntent(pendingIntent)
         .setGroup(ARTICLE_NOTIFICATION_GROUP)
         .setGroupAlertBehavior(GROUP_ALERT_SUMMARY)
         .setDeleteIntent(getPendingDeleteIntent(context, item))
@@ -178,19 +173,6 @@ private suspend fun singleNotification(
         .setNumber(1)
 
     // Note that notifications must use PNG resources, because there is no compatibility for vector drawables here
-
-    if (repository.getArticleOpener(item.id) == ItemOpener.DEFAULT_BROWSER && item.link != null) {
-        builder.setContentIntent(
-            PendingIntent.getActivity(
-                context,
-                item.id.toInt(),
-                getOpenInDefaultActivityIntent(context, item.id, item.link),
-                PendingIntent.FLAG_UPDATE_CURRENT or FLAG_IMMUTABLE,
-            ),
-        )
-    } else {
-        builder.setContentIntent(pendingIntent)
-    }
 
     item.enclosureLink?.let { enclosureLink ->
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse(enclosureLink))
@@ -207,7 +189,7 @@ private suspend fun singleNotification(
         )
     }
 
-    if (repository.getArticleOpener(item.id) != ItemOpener.DEFAULT_BROWSER) {
+    if (articleOpener != ItemOpener.DEFAULT_BROWSER) {
         item.link?.let { link ->
             builder.addAction(
                 R.drawable.notification_open_in_browser,
@@ -236,6 +218,31 @@ private suspend fun singleNotification(
     style.setBuilder(builder)
     return style.build() ?: error("Null??")
 }
+
+internal fun getArticleNotificationIntent(
+    context: Context,
+    feedItemId: Long,
+    link: String?,
+    articleOpener: ItemOpener,
+): Intent =
+    when {
+        link == null || articleOpener == ItemOpener.READER ->
+            Intent(
+                Intent.ACTION_VIEW,
+                "$DEEP_LINK_BASE_URI/article/$feedItemId".toUri(),
+                context,
+                MainActivity::class.java,
+            ).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+
+        articleOpener == ItemOpener.CUSTOM_TAB ->
+            getOpenInDefaultActivityIntent(context, feedItemId, link).apply {
+                action = ACTION_OPEN_IN_CUSTOM_TAB
+            }
+
+        else -> getOpenInDefaultActivityIntent(context, feedItemId, link)
+    }
 
 internal fun getOpenInDefaultActivityIntent(
     context: Context,

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/OpenLinkInDefaultActivity.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/OpenLinkInDefaultActivity.kt
@@ -9,6 +9,7 @@ import com.nononsenseapps.feeder.R
 import com.nononsenseapps.feeder.base.DIAwareComponentActivity
 import com.nononsenseapps.feeder.db.COL_LINK
 import com.nononsenseapps.feeder.db.room.ID_UNSET
+import com.nononsenseapps.feeder.model.ACTION_OPEN_IN_CUSTOM_TAB
 import com.nononsenseapps.feeder.model.cancelNotification
 import com.nononsenseapps.feeder.util.ActivityLauncher
 import com.nononsenseapps.feeder.util.DEEP_LINK_HOST
@@ -68,10 +69,18 @@ class OpenLinkInDefaultActivity : DIAwareComponentActivity() {
 
         if (link != null) {
             try {
-                activityLauncher.openLinkInBrowser(
-                    link,
-                    openAdjacentIfSuitable = false,
-                )
+                if (intent.action == ACTION_OPEN_IN_CUSTOM_TAB) {
+                    activityLauncher.openLinkInCustomTab(
+                        link,
+                        toolbarColor = getColor(R.color.primary),
+                        openAdjacentIfSuitable = false,
+                    )
+                } else {
+                    activityLauncher.openLinkInBrowser(
+                        link,
+                        openAdjacentIfSuitable = false,
+                    )
+                }
             } catch (e: Throwable) {
                 e.printStackTrace()
                 Toast.makeText(this, R.string.no_activity_for_link, Toast.LENGTH_SHORT).show()


### PR DESCRIPTION
## What does this change?

Makes article-notification taps honor each feed's configured article opener. Custom-tab feeds now open the article in a custom tab, while reader and default-browser behavior remain unchanged.

The custom-tab route continues through the existing notification proxy so the item is marked read and notified and its notification is cancelled. A distinct intent action prevents the content tap from colliding with the notification's separate browser action.

Closes #879

## Checklist

- [x] Ran `./gradlew ktlintFormat`
- [x] Room schema unchanged; no migration required

## Testing

- 9 focused API 30 managed-device notification intent tests
- Full JVM test suite
- F-Droid debug APK assembly
- `ktlintCheck`
- `git diff --check`

## Screenshots

Not applicable; this changes notification routing without changing app UI layout.
