### PR TITLE
fix: format dates with device preferred 12/24-hour clock

### DIFF
--- a/app/src/androidTest/java/com/nononsenseapps/feeder/DateFormattingTest.kt
+++ b/app/src/androidTest/java/com/nononsenseapps/feeder/DateFormattingTest.kt
@@ -1,0 +1,92 @@
+package com.nononsenseapps.feeder
+
+import android.content.Context
+import android.content.res.Configuration
+import android.os.ParcelFileDescriptor
+import android.provider.Settings
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.nononsenseapps.feeder.archmodel.formatForFeed
+import com.nononsenseapps.feeder.ui.compose.feedarticle.formatArticleDate
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.util.Locale
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@RunWith(AndroidJUnit4::class)
+class DateFormattingTest {
+    private lateinit var context: Context
+    private var originalTimeFormat: String? = null
+
+    @Before
+    fun setUp() {
+        val applicationContext = ApplicationProvider.getApplicationContext<Context>()
+        val configuration = Configuration(applicationContext.resources.configuration).apply { setLocale(Locale.US) }
+        context = applicationContext.createConfigurationContext(configuration)
+        originalTimeFormat = Settings.System.getString(context.contentResolver, Settings.System.TIME_12_24)
+    }
+
+    @After
+    fun tearDown() {
+        setTimeFormat(originalTimeFormat)
+    }
+
+    @Test
+    fun feedAndWidgetDatesUseClockPreferenceAndLocalTimeZone() {
+        val zoneId = ZoneId.of("Asia/Kolkata")
+        val today = LocalDate.of(2026, 7, 20)
+        val publicationDate = ZonedDateTime.parse("2026-07-19T23:30:00Z")
+
+        setTimeFormat("24")
+        assertEquals("05:00", publicationDate.formatForFeed(context, zoneId, today))
+
+        setTimeFormat("12")
+        val twelveHourTime = publicationDate.formatForFeed(context, zoneId, today)
+        assertTrue(twelveHourTime.contains("5:00"))
+        assertTrue(twelveHourTime.contains("AM"))
+
+        val olderPublicationDate = ZonedDateTime.parse("2026-07-18T23:30:00Z")
+        assertEquals("Jul 19, 2026", olderPublicationDate.formatForFeed(context, zoneId, today))
+        assertEquals("", null.formatForFeed(context, zoneId, today))
+    }
+
+    @Test
+    fun articleDateUsesClockPreferenceWithFullLocalizedDate() {
+        val publicationDate = ZonedDateTime.parse("2026-07-20T12:35:00Z")
+        val zoneId = ZoneId.of("Asia/Kolkata")
+
+        setTimeFormat("24")
+        val twentyFourHourDate = formatArticleDate(context, publicationDate, zoneId)
+        assertTrue(twentyFourHourDate.contains("Monday"))
+        assertTrue(twentyFourHourDate.contains("July"))
+        assertTrue(twentyFourHourDate.contains("20"))
+        assertTrue(twentyFourHourDate.contains("2026"))
+        assertTrue(twentyFourHourDate.contains("18:05"))
+        assertFalse(twentyFourHourDate.contains("PM"))
+
+        setTimeFormat("12")
+        val twelveHourDate = formatArticleDate(context, publicationDate, zoneId)
+        assertTrue(twelveHourDate.contains("6:05"))
+        assertTrue(twelveHourDate.contains("PM"))
+        assertEquals("", formatArticleDate(context, null, zoneId))
+    }
+
+    private fun setTimeFormat(value: String?) {
+        val command =
+            if (value == null) {
+                "settings delete system ${Settings.System.TIME_12_24}"
+            } else {
+                "settings put system ${Settings.System.TIME_12_24} $value"
+            }
+        val output = InstrumentationRegistry.getInstrumentation().uiAutomation.executeShellCommand(command)
+        ParcelFileDescriptor.AutoCloseInputStream(output).use { it.readBytes() }
+    }
+}

--- a/app/src/main/java/com/nononsenseapps/feeder/archmodel/FeedItemStore.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/archmodel/FeedItemStore.kt
@@ -1,5 +1,8 @@
 package com.nononsenseapps.feeder.archmodel
 
+import android.app.Application
+import android.content.Context
+import android.text.format.DateFormat
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
@@ -31,11 +34,10 @@ import org.kodein.di.instance
 import java.net.URL
 import java.time.Instant
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.ZoneId
-import java.time.format.DateTimeFormatter
-import java.time.format.FormatStyle
-import java.util.Locale
+import java.time.ZonedDateTime
+import java.util.Date
+import java.util.TimeZone
 
 class FeedItemStore(
     override val di: DI,
@@ -44,6 +46,7 @@ class FeedItemStore(
     private val blocklistDao: BlocklistDao by instance()
     private val appDatabase: AppDatabase by instance()
     private val settingsStore: SettingsStore by instance()
+    private val application: Application by instance()
 
     suspend fun setBlockStatusForNewInFeed(
         feedId: Long,
@@ -82,7 +85,7 @@ class FeedItemStore(
             feedId > ID_UNSET -> dao.widgetPreviewsByFeed(feedId)
             tag.isNotEmpty() -> dao.widgetPreviewsByTag(tag)
             else -> dao.widgetPreviewsAllFeeds()
-        }.map { list -> list.map { it.toFeedListItem() } }
+        }.map { list -> list.map { it.toFeedListItem(application) } }
 
     fun getPagedFeedItemsRaw(
         feedId: Long,
@@ -121,7 +124,7 @@ class FeedItemStore(
         }.flow
             .map { pagingData ->
                 pagingData
-                    .map { it.toFeedListItem() }
+                    .map { it.toFeedListItem(application) }
             }
 
     private fun StringBuilder.rawQueryFilter(
@@ -356,20 +359,14 @@ class FeedItemStore(
     suspend fun getArticle(id: Long): FeedItemWithFeed? = dao.getFeedItem(id)
 }
 
-val mediumDateTimeFormat: DateTimeFormatter =
-    DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withLocale(Locale.getDefault())
-
-val shortTimeFormat: DateTimeFormatter =
-    DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).withLocale(Locale.getDefault())
-
-private fun PreviewItem.toFeedListItem() =
+private fun PreviewItem.toFeedListItem(context: Context) =
     FeedListItem(
         id = id,
         title = plainTitle,
         snippet = plainSnippet,
         feedTitle = feedDisplayTitle,
         unread = readTime == null,
-        pubDate = pubDate?.withZoneSameInstant(ZoneId.systemDefault())?.toLocalDateTime()?.formatDynamically() ?: "",
+        pubDate = pubDate.formatForFeed(context),
         image = image,
         link = link,
         bookmarked = bookmarked,
@@ -379,10 +376,18 @@ private fun PreviewItem.toFeedListItem() =
         wordCount = bestWordCount,
     )
 
-private fun LocalDateTime.formatDynamically(): String {
-    val today = LocalDate.now().atStartOfDay()
-    return when {
-        this >= today -> format(shortTimeFormat)
-        else -> format(mediumDateTimeFormat)
-    }
-}
+internal fun ZonedDateTime?.formatForFeed(
+    context: Context,
+    zoneId: ZoneId = ZoneId.systemDefault(),
+    today: LocalDate = LocalDate.now(zoneId),
+): String =
+    this?.let { publicationDate ->
+        val formatter =
+            if (publicationDate.withZoneSameInstant(zoneId).toLocalDate() >= today) {
+                DateFormat.getTimeFormat(context)
+            } else {
+                DateFormat.getMediumDateFormat(context)
+            }
+        formatter.timeZone = TimeZone.getTimeZone(zoneId)
+        formatter.format(Date.from(publicationDate.toInstant()))
+    } ?: ""

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleScreen.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleScreen.kt
@@ -1,6 +1,8 @@
 package com.nononsenseapps.feeder.ui.compose.feedarticle
 
+import android.content.Context
 import android.content.Intent
+import android.text.format.DateFormat
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.foundation.ScrollState
@@ -86,8 +88,11 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.launch
 import org.kodein.di.compose.LocalDI
 import org.kodein.di.instance
+import java.text.SimpleDateFormat
 import java.time.ZoneId
 import java.time.ZonedDateTime
+import java.util.Date
+import java.util.TimeZone
 
 @Composable
 fun ArticleScreen(
@@ -561,9 +566,7 @@ fun ArticleContent(
                 viewState.author == null && viewState.pubDate != null ->
                     stringResource(
                         R.string.on_date,
-                        (viewState.pubDate?.withZoneSameInstant(ZoneId.systemDefault()) ?: ZonedDateTime.now()).format(
-                            dateTimeFormat,
-                        ),
+                        formatArticleDate(context, viewState.pubDate),
                     )
 
                 viewState.author != null && viewState.pubDate != null ->
@@ -572,9 +575,7 @@ fun ArticleContent(
                         // Must wrap author in unicode marks to ensure it formats
                         // correctly in RTL
                         context.unicodeWrap(viewState.author ?: ""),
-                        (viewState.pubDate?.withZoneSameInstant(ZoneId.systemDefault()) ?: ZonedDateTime.now()).format(
-                            dateTimeFormat,
-                        ),
+                        formatArticleDate(context, viewState.pubDate),
                     )
 
                 else -> null
@@ -658,6 +659,19 @@ fun ArticleContent(
         }
     }
 }
+
+internal fun formatArticleDate(
+    context: Context,
+    publicationDate: ZonedDateTime?,
+    zoneId: ZoneId = ZoneId.systemDefault(),
+): String =
+    publicationDate?.let {
+        val skeleton = if (DateFormat.is24HourFormat(context)) "yMMMMEEEEdHm" else "yMMMMEEEEdhm"
+        val locale = context.resources.configuration.locales[0]
+        SimpleDateFormat(DateFormat.getBestDateTimePattern(locale, skeleton), locale)
+            .apply { timeZone = TimeZone.getTimeZone(zoneId) }
+            .format(Date.from(it.toInstant()))
+    } ?: ""
 
 @Composable
 private fun SummarySection(summary: OpenAISummaryState) {


### PR DESCRIPTION
## What does this change?

Makes publication timestamps follow the device's 12/24-hour clock preference in feed rows, widgets, and article headers.

Formatting remains locale-aware and uses the system timezone. Feed entries from today or the future continue to show a time, older entries continue to show a medium date, and missing dates remain blank.

Closes #813

## Checklist

- [x] Ran `./gradlew ktlintFormat`
- [x] Room schema unchanged; no migration required

## Testing

- 2 focused API 30 managed-device date-formatting tests
- Full JVM test suite
- Production, JVM-test, and Android-test Kotlin compilation
- F-Droid debug APK assembly
- `ktlintCheck`
- `git diff --check`

## Screenshots

Not included; automated device tests cover both 12-hour and 24-hour output.
