### PR TITLE
feat: added setting to force single column feed

### DIFF
--- a/app/src/androidTest/java/com/nononsenseapps/feeder/model/opml/OPMLTest.kt
+++ b/app/src/androidTest/java/com/nononsenseapps/feeder/model/opml/OPMLTest.kt
@@ -793,6 +793,7 @@ class OPMLTest : DIAware {
                         UserSettings.SETTING_TRANSLATION_API_REQUEST_TIMEOUT_SECONDS -> "90"
                         UserSettings.SETTING_TRANSLATE_ARTICLE_PREVIEWS_BY_DEFAULT -> "true"
                         UserSettings.SETTING_TRANSLATE_ARTICLES_BY_DEFAULT -> "false"
+                        UserSettings.SETTINGS_FORCE_SINGLE_COLUMN -> "false"
                     }
             }
     }
@@ -881,6 +882,7 @@ private val sampleFile: List<String> =
           <feeder:setting key="pref_translation_api_request_timeout_seconds" value="90"/>
           <feeder:setting key="pref_translate_feed_cards_by_default" value="true"/>
           <feeder:setting key="pref_translate_articles_by_default" value="false"/>
+          <feeder:setting key="pref_force_single_column" value="false"/>
           <feeder:blocked pattern="foo"/>
         </feeder:settings>
       </body>

--- a/app/src/main/java/com/nononsenseapps/feeder/archmodel/Repository.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/archmodel/Repository.kt
@@ -386,6 +386,10 @@ class Repository(
 
     fun setOpenDrawerOnFab(value: Boolean) = settingsStore.setOpenDrawerOnFab(value)
 
+    val forceSingleColumn = settingsStore.forceSingleColumn
+
+    fun setForceSingleColumn(value: Boolean) = settingsStore.setForceSingleColumn(value)
+
     /**
      * Returns true if the latest sync timestamp is within the last 10 seconds
      */

--- a/app/src/main/java/com/nononsenseapps/feeder/archmodel/SettingsStore.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/archmodel/SettingsStore.kt
@@ -608,6 +608,14 @@ class SettingsStore(
         sp.edit().putBoolean(PREF_OPEN_DRAWER_ON_FAB, value).apply()
     }
 
+    private val _forceSingleColumn = MutableStateFlow(sp.getBoolean(PREF_FORCE_SINGLE_COLUMN, false))
+    val forceSingleColumn = _forceSingleColumn.asStateFlow()
+
+    fun setForceSingleColumn(value: Boolean) {
+        _forceSingleColumn.value = value
+        sp.edit().putBoolean(PREF_FORCE_SINGLE_COLUMN, value).apply()
+    }
+
     fun getAllSettings(): Map<String, String> {
         val all = sp.all ?: emptyMap()
 
@@ -747,6 +755,7 @@ const val PREF_TRANSLATE_ARTICLES_BY_DEFAULT = "pref_translate_articles_by_defau
  * Appearance settings
  */
 const val PREF_SHOW_TITLE_UNREAD_COUNT = "pref_show_title_unread_count"
+const val PREF_FORCE_SINGLE_COLUMN = "pref_force_single_column"
 
 /**
  * Used for OPML Import/Export. Please add new (only) user configurable settings here
@@ -807,6 +816,7 @@ enum class UserSettings(
     SETTING_TRANSLATION_API_REQUEST_TIMEOUT_SECONDS(key = PREF_TRANSLATION_API_REQUEST_TIMEOUT_SECONDS),
     SETTING_TRANSLATE_ARTICLE_PREVIEWS_BY_DEFAULT(key = PREF_TRANSLATE_ARTICLE_PREVIEWS_BY_DEFAULT),
     SETTING_TRANSLATE_ARTICLES_BY_DEFAULT(key = PREF_TRANSLATE_ARTICLES_BY_DEFAULT),
+    SETTINGS_FORCE_SINGLE_COLUMN(key = PREF_FORCE_SINGLE_COLUMN),
     ;
 
     companion object {

--- a/app/src/main/java/com/nononsenseapps/feeder/model/opml/OPMLImporter.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/opml/OPMLImporter.kt
@@ -107,6 +107,7 @@ open class OPMLImporter(
             UserSettings.SETTING_LIST_SHOW_READING_TIME -> settingsStore.setShowReadingTime(value.toBoolean())
             UserSettings.SETTING_OPEN_DRAWER_ON_FAB -> settingsStore.setOpenDrawerOnFab(value.toBoolean())
             UserSettings.SETTING_SHOW_TITLE_UNREAD_COUNT -> settingsStore.setShowTitleUnreadCount(value.toBoolean())
+            UserSettings.SETTINGS_FORCE_SINGLE_COLUMN -> settingsStore.setForceSingleColumn(value.toBoolean())
             UserSettings.SETTING_MAX_ITEM_COUNT_PER_FEED -> settingsStore.setMaxCountPerFeed(value.toIntOrNull() ?: 100)
             UserSettings.SETTING_TRANSLATE_ARTICLE_PREVIEWS_BY_DEFAULT -> settingsStore.setTranslateArticlePreviewsByDefault(value.toBoolean())
             UserSettings.SETTING_TRANSLATE_ARTICLES_BY_DEFAULT -> settingsStore.setTranslateArticlesByDefault(value.toBoolean())

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feed/FeedScreen.kt
@@ -1677,7 +1677,7 @@ fun FeedGridContent(
         ) {
             LazyVerticalStaggeredGrid(
                 state = gridState,
-                columns = StaggeredGridCells.Fixed(LocalDimens.current.feedScreenColumns),
+                columns = StaggeredGridCells.Fixed(if (viewState.forceSingleColumn) 1 else LocalDimens.current.feedScreenColumns),
                 contentPadding =
                     if (viewState.isBottomBarVisible) {
                         PaddingValues(0.dp)

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/FeedViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/FeedViewModel.kt
@@ -492,6 +492,7 @@ class FeedViewModel(
             bergamotModelManager.downloadProgress,
             renameTagDialogVisible,
             podcastPlayerStateHolder.playerState,
+            repository.forceSingleColumn,
         ) { params: Array<Any?> ->
             val haveVisibleFeedItems = (params[7] as Int) > 0
             val currentFeedOrTag = params[13] as FeedOrTag
@@ -534,6 +535,7 @@ class FeedViewModel(
                 showTitleUnreadCount = params[25] as Boolean,
                 isOpenDrawerOnFab = params[27] as Boolean,
                 translationModelDownloadProgress = params[28] as BergamotModelDownloadProgress?,
+                forceSingleColumn = params[31] as Boolean,
             )
         }.stateIn(
             viewModelScope,
@@ -687,6 +689,7 @@ data class FeedState(
     override val showTitleUnreadCount: Boolean = false,
     override val isOpenDrawerOnFab: Boolean = false,
     override val translationModelDownloadProgress: BergamotModelDownloadProgress? = null,
+    override val forceSingleColumn: Boolean = false,
 ) : FeedScreenViewState
 
 @Immutable
@@ -721,6 +724,7 @@ interface FeedScreenViewState {
     val showTitleUnreadCount: Boolean
     val isOpenDrawerOnFab: Boolean
     val translationModelDownloadProgress: BergamotModelDownloadProgress?
+    val forceSingleColumn: Boolean
 }
 
 private data class FeedCardTranslationConfig(

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/settings/Settings.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/settings/Settings.kt
@@ -259,6 +259,8 @@ fun SettingsScreen(
             onDeleteLanguagePair = { source, target ->
                 settingsViewModel.deleteLanguagePair(source, target)
             },
+            forceSingleColumn = viewState.forceSingleColumn,
+            onForceSingleColumnChange = settingsViewModel::setForceSingleColumn,
             modifier = Modifier.padding(padding),
         )
     }
@@ -350,6 +352,8 @@ private fun SettingsScreenPreview() {
             onSendFeedback = {},
             downloadedLanguagePairs = emptyList(),
             onDeleteLanguagePair = { _, _ -> },
+            forceSingleColumn = false,
+            onForceSingleColumnChange = {},
             modifier = Modifier,
         )
     }
@@ -437,6 +441,8 @@ fun SettingsList(
     onSendFeedback: () -> Unit,
     downloadedLanguagePairs: List<LanguagePairInfo>,
     onDeleteLanguagePair: (source: String, target: String) -> Unit,
+    forceSingleColumn: Boolean,
+    onForceSingleColumnChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
@@ -726,6 +732,12 @@ fun SettingsList(
                 title = stringResource(id = R.string.show_title_unread_count),
                 checked = showTitleUnreadCount,
                 onCheckedChange = onShowTitleUnreadCountChange,
+            )
+
+            SwitchSetting(
+                title = stringResource(id = R.string.force_single_column),
+                checked = forceSingleColumn,
+                onCheckedChange = onForceSingleColumnChange,
             )
         }
 

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/settings/SettingsViewModel.kt
@@ -182,6 +182,10 @@ class SettingsViewModel(
         repository.setIsPagingMode(value)
     }
 
+    fun setForceSingleColumn(value: Boolean) {
+        repository.setForceSingleColumn(value)
+    }
+
     fun setIsAnimatedPaging(value: Boolean) {
         repository.setIsAnimatedPaging(value)
     }
@@ -308,6 +312,7 @@ class SettingsViewModel(
                 repository.isAnimatedPaging,
                 downloadedLanguagePairs,
                 repository.useInAppAudioPlayer,
+                repository.forceSingleColumn,
             ) { params: Array<Any> ->
                 @Suppress("UNCHECKED_CAST")
                 SettingsViewState(
@@ -358,6 +363,7 @@ class SettingsViewModel(
                     isAnimatedPaging = params[37] as Boolean,
                     translationModelPairs = params[38] as List<LanguagePairInfo>,
                     useInAppAudioPlayer = params[39] as Boolean,
+                    forceSingleColumn = params[40] as Boolean,
                 )
             }.collect {
                 _viewState.value = it
@@ -452,6 +458,7 @@ data class SettingsViewState(
     val isPagingMode: Boolean = false,
     val isAnimatedPaging: Boolean = false,
     val useInAppAudioPlayer: Boolean = true,
+    val forceSingleColumn: Boolean = true,
 )
 
 data class UIFeedSettings(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -396,4 +396,5 @@
 
   <string name="widget_title">Feeder</string>
   <string name="widget_refreshing">Refreshing</string>
+  <string name="force_single_column">Force single column</string>
 </resources>

--- a/app/src/test/java/com/nononsenseapps/feeder/archmodel/SettingsStoreTest.kt
+++ b/app/src/test/java/com/nononsenseapps/feeder/archmodel/SettingsStoreTest.kt
@@ -393,6 +393,17 @@ class SettingsStoreTest : DIAware {
     }
 
     @Test
+    fun forceSingleColumn() {
+        store.setForceSingleColumn(true)
+
+        verify {
+            sp.edit().putBoolean(PREF_FORCE_SINGLE_COLUMN, true).apply()
+        }
+
+        assertEquals(true, store.forceSingleColumn.value)
+    }
+
+    @Test
     fun applyBlocklistToSummariesDefaultsToFalse() {
         every { sp.getBoolean(PREF_BLOCKLIST_APPLY_TO_SUMMARIES, false) } returns false
 

--- a/app/src/test/java/com/nononsenseapps/feeder/model/opml/OpmlParserTest.kt
+++ b/app/src/test/java/com/nononsenseapps/feeder/model/opml/OpmlParserTest.kt
@@ -102,6 +102,7 @@ class OpmlParserTest : DIAware {
                         UserSettings.SETTING_TRANSLATION_API_REQUEST_TIMEOUT_SECONDS -> "90"
                         UserSettings.SETTING_TRANSLATE_ARTICLE_PREVIEWS_BY_DEFAULT -> "true"
                         UserSettings.SETTING_TRANSLATE_ARTICLES_BY_DEFAULT -> "true"
+                        UserSettings.SETTINGS_FORCE_SINGLE_COLUMN -> "true"
                     },
             )
         }
@@ -157,6 +158,7 @@ class OpmlParserTest : DIAware {
                 settingsStore.setTranslateArticlePreviewsByDefault(true)
                 settingsStore.setTranslateArticlesByDefault(true)
                 settingsStore.setApplyBlocklistToSummaries(true)
+                settingsStore.setForceSingleColumn(true)
             }
 
             confirmVerified(settingsStore)

--- a/app/src/test/java/com/nononsenseapps/feeder/model/opml/OpmlWriterKtTest.kt
+++ b/app/src/test/java/com/nononsenseapps/feeder/model/opml/OpmlWriterKtTest.kt
@@ -163,6 +163,7 @@ class OpmlWriterKtTest {
               <feeder:setting key="pref_translation_api_request_timeout_seconds" value="90"/>
               <feeder:setting key="pref_translate_feed_cards_by_default" value="true"/>
               <feeder:setting key="pref_translate_articles_by_default" value="true"/>
+              <feeder:setting key="pref_force_single_column" value="true"/>
               <feeder:blocked pattern="foo"/>
               <feeder:blocked pattern="break &quot;xml id &apos;9&apos; &gt; 0 &amp; &lt; 10"/>
             </feeder:settings>
@@ -224,6 +225,7 @@ class OpmlWriterKtTest {
                         UserSettings.SETTING_TRANSLATION_API_REQUEST_TIMEOUT_SECONDS -> "90"
                         UserSettings.SETTING_TRANSLATE_ARTICLE_PREVIEWS_BY_DEFAULT -> "true"
                         UserSettings.SETTING_TRANSLATE_ARTICLES_BY_DEFAULT -> "true"
+                        UserSettings.SETTINGS_FORCE_SINGLE_COLUMN -> "true"
                     }
             }
     }


### PR DESCRIPTION
## What does this change?

Add a setting to force single column layout on tablets (or other large screens). This setting is off by default to retain existing behavior unless the user opts in. When enabled, it will override existing column selection logic and limit columns to 1.

Why? I find it easier to follow a single direction list. And on my smaller tablet the two column layout makes each card smaller than the single column on my phone, which I find a bit too thin.

fixes #494 


## Checklist

- [X] Ran `./gradlew ktlintFormat` and committed the result
- [ ] ~~If the Room schema changed: added a `MIGRATION_N_N+1` in `AppDatabase.kt`~~
- [ ] ~~If the Room schema changed: added a migration test in `app/src/androidTest/.../db/room/`~~

*Struck through items are not applicable*

## Screenshots (if UI change)

2 column layout (existing behavior on tablet):
<img height="400" alt="2col" src="https://github.com/user-attachments/assets/2ac1de6d-fab9-49f1-810f-16329dc75604" />

1 column layout forced on tablet:
<img height="400" alt="1col" src="https://github.com/user-attachments/assets/4ce1cb80-1950-422f-88a7-f2dc2e679e68" />

New setting:
<img height="400" alt="setting" src="https://github.com/user-attachments/assets/9fdb9438-dd66-4adb-8e63-1d75eac3bbf8" />



