### PR TITLE
Reintroduced ability to download audio file from article link

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleScreen.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleScreen.kt
@@ -637,6 +637,9 @@ fun ArticleContent(
                 }
             }
         },
+        onEnclosureLongPress = {
+            activityLauncher.openLinkInBrowser(link = viewState.enclosure.link)
+        },
         onFeedTitleClick = onFeedTitleClick,
         enclosure = viewState.enclosure,
         articleTitle = viewState.articleTitle,

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ReaderView.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ReaderView.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.indication
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -38,6 +39,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.pluralStringResource
@@ -88,6 +90,7 @@ fun ReaderView(
     screenType: ScreenType,
     wordCount: Int,
     onEnclosureClick: () -> Unit,
+    onEnclosureLongPress: () -> Unit,
     onFeedTitleClick: () -> Unit,
     enclosure: Enclosure,
     articleTitle: String,
@@ -273,8 +276,11 @@ fun ReaderView(
                                     modifier =
                                         Modifier
                                             .width(dimens.maxReaderWidth)
-                                            .clickable {
-                                                onEnclosureClick()
+                                            .pointerInput(Unit) {
+                                                detectTapGestures(
+                                                    onTap = { onEnclosureClick() },
+                                                    onLongPress = { onEnclosureLongPress() },
+                                                )
                                             }.clearAndSetSemantics {
                                                 try {
                                                     customActions =
@@ -379,6 +385,7 @@ private fun ReaderPreview() {
                 screenType = ScreenType.SINGLE,
                 wordCount = 9700,
                 onEnclosureClick = {},
+                onEnclosureLongPress = {},
                 onFeedTitleClick = {},
                 enclosure = Enclosure(),
                 articleTitle = "Article title on top",


### PR DESCRIPTION
## What does this change?

Long pressing the "Open..." link in the article opens the audio link in the browser or whatever default is set for the system.

This ability was lost with #1172 afaik , and I wanted to keep the ability to download the files locally (The new audio player is unable to keep playing if the application loses focus on my device).

## Checklist

- [X] Ran `./gradlew ktlintFormat` and committed the result

