### PR TITLE
feat: added 'Apply to links' toggle to blocklist feature

### DIFF
--- a/app/src/androidTest/java/com/nononsenseapps/feeder/db/room/BlocklistDaoTest.kt
+++ b/app/src/androidTest/java/com/nononsenseapps/feeder/db/room/BlocklistDaoTest.kt
@@ -54,12 +54,12 @@ class BlocklistDaoTest {
     }
 
     @Test
-    fun blockByTitleOnly_doesNotBlockBySnippet() =
+    fun blockByTitleOnly_doesNotBlockBySnippetAndLink() =
         runBlocking {
             // Add blocklist pattern
             blocklistDao.insertSafely("blocked")
 
-            // Create items - one with blocked title, one with blocked snippet
+            // Create items - one with blocked title, one with blocked snippet, one with blocked link
             val item1Id =
                 feedItemDao.insertFeedItem(
                     FeedItem(
@@ -68,6 +68,7 @@ class BlocklistDaoTest {
                         plainTitle = "This contains blocked word",
                         plainSnippet = "Normal snippet",
                         pubDate = ZonedDateTime.now(),
+                        link = "https://example.com/article",
                     ),
                 )
             val item2Id =
@@ -78,6 +79,7 @@ class BlocklistDaoTest {
                         plainTitle = "Normal title",
                         plainSnippet = "This contains blocked word",
                         pubDate = ZonedDateTime.now(),
+                        link = "https://example.com/article",
                     ),
                 )
             val item3Id =
@@ -88,29 +90,43 @@ class BlocklistDaoTest {
                         plainTitle = "Clean title",
                         plainSnippet = "Clean snippet",
                         pubDate = ZonedDateTime.now(),
+                        link = "https://example.com/article",
+                    ),
+                )
+            val item4Id =
+                feedItemDao.insertFeedItem(
+                    FeedItem(
+                        guid = "item4",
+                        feedId = testFeedId,
+                        plainTitle = "Normal title",
+                        plainSnippet = "Normal snippet",
+                        pubDate = ZonedDateTime.now(),
+                        link = "https://example.com/blocked",
                     ),
                 )
 
             // Block with title only (applyToSummaries = false)
-            blocklistDao.setItemBlockStatus(blockTime, applyToSummaries = false)
+            blocklistDao.setItemBlockStatus(blockTime, applyToSummaries = false, applyToLinks = false)
 
-            // Verify: item1 should be blocked, item2 should NOT be blocked, item3 should not be blocked
+            // Verify: item1 should be blocked, item2 should NOT be blocked, item3 should not be blocked, item4 should NOT be blocked
             val retrievedItem1 = feedItemDao.loadFeedItem(item1Id)
             val retrievedItem2 = feedItemDao.loadFeedItem(item2Id)
             val retrievedItem3 = feedItemDao.loadFeedItem(item3Id)
+            val retrievedItem4 = feedItemDao.loadFeedItem(item4Id)
 
             assertNotNull("Item1 should be blocked", retrievedItem1?.blockTime)
             assertNull("Item2 should NOT be blocked (title-only mode)", retrievedItem2?.blockTime)
             assertNull("Item3 should not be blocked", retrievedItem3?.blockTime)
+            assertNull("Item4 should NOT be blocked (title-only mode)", retrievedItem4?.blockTime)
         }
 
     @Test
-    fun blockByTitleAndSnippet_blocksFromBoth() =
+    fun blockByTitleSnippetAndLink_blocksFromSnippetOrLink() =
         runBlocking {
             // Add blocklist pattern
             blocklistDao.insertSafely("blocked")
 
-            // Create items - one with blocked title, one with blocked snippet
+            // Create items - one with blocked title, one with blocked snippet, one with blocked link
             val item1Id =
                 feedItemDao.insertFeedItem(
                     FeedItem(
@@ -119,6 +135,7 @@ class BlocklistDaoTest {
                         plainTitle = "This contains blocked word",
                         plainSnippet = "Normal snippet",
                         pubDate = ZonedDateTime.now(),
+                        link = "https://example.com/article",
                     ),
                 )
             val item2Id =
@@ -129,6 +146,7 @@ class BlocklistDaoTest {
                         plainTitle = "Normal title",
                         plainSnippet = "This contains blocked word",
                         pubDate = ZonedDateTime.now(),
+                        link = "https://example.com/article",
                     ),
                 )
             val item3Id =
@@ -139,20 +157,48 @@ class BlocklistDaoTest {
                         plainTitle = "Clean title",
                         plainSnippet = "Clean snippet",
                         pubDate = ZonedDateTime.now(),
+                        link = "https://example.com/article",
+                    ),
+                )
+            val item4Id =
+                feedItemDao.insertFeedItem(
+                    FeedItem(
+                        guid = "item4",
+                        feedId = testFeedId,
+                        plainTitle = "Normal title",
+                        plainSnippet = "Normal snippet",
+                        pubDate = ZonedDateTime.now(),
+                        link = "https://example.com/blocked",
                     ),
                 )
 
-            // Block with title AND snippet (applyToSummaries = true)
-            blocklistDao.setItemBlockStatus(blockTime, applyToSummaries = true)
+            // Block with title AND snippet (applyToSummaries = true, applyToLinks = false)
+            blocklistDao.setItemBlockStatus(blockTime, applyToSummaries = true, applyToLinks = false)
 
-            // Verify: both item1 and item2 should be blocked, item3 should not
-            val retrievedItem1 = feedItemDao.loadFeedItem(item1Id)
-            val retrievedItem2 = feedItemDao.loadFeedItem(item2Id)
-            val retrievedItem3 = feedItemDao.loadFeedItem(item3Id)
+            // Verify: both item1 and item2 should be blocked, item3 and item4 should not
+            var retrievedItem1 = feedItemDao.loadFeedItem(item1Id)
+            var retrievedItem2 = feedItemDao.loadFeedItem(item2Id)
+            var retrievedItem3 = feedItemDao.loadFeedItem(item3Id)
+            var retrievedItem4 = feedItemDao.loadFeedItem(item4Id)
 
             assertNotNull("Item1 should be blocked", retrievedItem1?.blockTime)
             assertNotNull("Item2 should be blocked (title+snippet mode)", retrievedItem2?.blockTime)
             assertNull("Item3 should not be blocked", retrievedItem3?.blockTime)
+            assertNull("Item4 should NOT be blocked (title+snippet mode)", retrievedItem4?.blockTime)
+
+            // Block with title AND link (applyToSummaries = false, applyToLinks = true)
+            blocklistDao.setItemBlockStatus(blockTime, applyToSummaries = false, applyToLinks = true)
+
+            // Verify: both item1 and item4 should be blocked, item2 and item3 should not
+            retrievedItem1 = feedItemDao.loadFeedItem(item1Id)
+            retrievedItem2 = feedItemDao.loadFeedItem(item2Id)
+            retrievedItem3 = feedItemDao.loadFeedItem(item3Id)
+            retrievedItem4 = feedItemDao.loadFeedItem(item4Id)
+
+            assertNotNull("Item1 should be blocked", retrievedItem1?.blockTime)
+            assertNull("Item2 should NOT be blocked (title+link mode)", retrievedItem2?.blockTime)
+            assertNull("Item3 should not be blocked", retrievedItem3?.blockTime)
+            assertNotNull("Item4 should be blocked (title+link mode)", retrievedItem4?.blockTime)
         }
 
     @Test
@@ -187,7 +233,7 @@ class BlocklistDaoTest {
             val newBlockTime = Instant.now()
 
             // Block only where null
-            blocklistDao.setItemBlockStatusWhereNull(newBlockTime, applyToSummaries = false)
+            blocklistDao.setItemBlockStatusWhereNull(newBlockTime, applyToSummaries = false, applyToLinks = false)
 
             // Verify: item1 should have new block time, item2 should keep old block time
             val retrievedItem1 = feedItemDao.loadFeedItem(item1Id)
@@ -245,7 +291,7 @@ class BlocklistDaoTest {
                 )
 
             // Block only for first feed
-            blocklistDao.setItemBlockStatusForNewInFeed(testFeedId, blockTime, applyToSummaries = false)
+            blocklistDao.setItemBlockStatusForNewInFeed(testFeedId, blockTime, applyToSummaries = false, applyToLinks = false)
 
             // Verify: only item1 should be blocked
             val retrievedItem1 = feedItemDao.loadFeedItem(item1Id)
@@ -273,13 +319,13 @@ class BlocklistDaoTest {
                 )
 
             // Block
-            blocklistDao.setItemBlockStatus(blockTime, applyToSummaries = false)
+            blocklistDao.setItemBlockStatus(blockTime, applyToSummaries = false, applyToLinks = false)
             var retrievedItem = feedItemDao.loadFeedItem(itemId)
             assertNotNull("Item should be blocked", retrievedItem?.blockTime)
 
             // Remove pattern and re-run blocking
             blocklistDao.deletePattern("bad")
-            blocklistDao.setItemBlockStatus(Instant.now(), applyToSummaries = false)
+            blocklistDao.setItemBlockStatus(Instant.now(), applyToSummaries = false, applyToLinks = false)
 
             // Verify: item should be unblocked
             retrievedItem = feedItemDao.loadFeedItem(itemId)
@@ -313,7 +359,7 @@ class BlocklistDaoTest {
                     ),
                 )
 
-            blocklistDao.setItemBlockStatus(blockTime, applyToSummaries = false)
+            blocklistDao.setItemBlockStatus(blockTime, applyToSummaries = false, applyToLinks = false)
 
             // Both should be blocked due to wildcard pattern
             val retrievedItem1 = feedItemDao.loadFeedItem(item1Id)
@@ -339,7 +385,7 @@ class BlocklistDaoTest {
                     ),
                 )
 
-            blocklistDao.setItemBlockStatus(blockTime, applyToSummaries = false)
+            blocklistDao.setItemBlockStatus(blockTime, applyToSummaries = false, applyToLinks = false)
 
             val retrievedItem = feedItemDao.loadFeedItem(itemId)
             assertNotNull("Should match case-insensitively", retrievedItem?.blockTime)
@@ -382,7 +428,7 @@ class BlocklistDaoTest {
                     ),
                 )
 
-            blocklistDao.setItemBlockStatus(blockTime, applyToSummaries = false)
+            blocklistDao.setItemBlockStatus(blockTime, applyToSummaries = false, applyToLinks = false)
 
             val retrievedItem1 = feedItemDao.loadFeedItem(item1Id)
             val retrievedItem2 = feedItemDao.loadFeedItem(item2Id)

--- a/app/src/androidTest/java/com/nononsenseapps/feeder/db/room/BlocklistToggleTest.kt
+++ b/app/src/androidTest/java/com/nononsenseapps/feeder/db/room/BlocklistToggleTest.kt
@@ -56,8 +56,8 @@ class BlocklistToggleTest {
     @Test
     fun toggleApplyToSummaries_correctlyBlocksAndUnblocks() =
         runBlocking {
-            // Create an article where the keyword is ONLY in the snippet, not the title
-            val articleId =
+            // Create articles - one with keyword in snippet, one with keyword in link
+            val article1Id =
                 feedItemDao.insertFeedItem(
                     FeedItem(
                         guid = "test1",
@@ -65,71 +65,122 @@ class BlocklistToggleTest {
                         plainTitle = "Some Normal Title",
                         plainSnippet = "This article mentions citizens in the description.",
                         pubDate = ZonedDateTime.now(),
+                        link = "https://example.com/article",
+                    ),
+                )
+            val article2Id =
+                feedItemDao.insertFeedItem(
+                    FeedItem(
+                        guid = "test2",
+                        feedId = testFeedId,
+                        plainTitle = "Some Normal Title",
+                        plainSnippet = "Normal snippet",
+                        pubDate = ZonedDateTime.now(),
+                        link = "https://example.com/citizens",
                     ),
                 )
 
             // Add "citizens" to blocklist
             blocklistDao.insertSafely("citizens")
 
-            // Step 1: Apply blocklist with applyToSummaries = FALSE
-            blocklistDao.setItemBlockStatus(Instant.now(), applyToSummaries = false)
+            // Step 1: Apply blocklist with applyToSummaries = FALSE and applyToLinks = FALSE
+            blocklistDao.setItemBlockStatus(Instant.now(), applyToSummaries = false, applyToLinks = false)
 
-            var article = feedItemDao.loadFeedItem(articleId)
+            var article1 = feedItemDao.loadFeedItem(article1Id)
+            var article2 = feedItemDao.loadFeedItem(article2Id)
+
             assertNull(
-                "Article should NOT be blocked when checking title only (toggle OFF)",
-                article?.blockTime,
+                "Article1 should NOT be blocked when checking title only (toggle OFF)",
+                article1?.blockTime,
+            )
+            assertNull(
+                "Article2 should NOT be blocked when checking title only (toggle OFF)",
+                article2?.blockTime,
             )
 
-            // Step 2: Apply blocklist with applyToSummaries = TRUE
-            blocklistDao.setItemBlockStatus(Instant.now(), applyToSummaries = true)
+            // Step 2: Apply blocklist with applyToSummaries = TRUE and applyToLinks = TRUE
+            blocklistDao.setItemBlockStatus(Instant.now(), applyToSummaries = true, applyToLinks = true)
 
-            article = feedItemDao.loadFeedItem(articleId)
+            article1 = feedItemDao.loadFeedItem(article1Id)
+            article2 = feedItemDao.loadFeedItem(article2Id)
+
             assertNotNull(
-                "Article SHOULD be blocked when checking summaries (toggle ON)",
-                article?.blockTime,
+                "Article1 SHOULD be blocked when checking summaries (toggle ON)",
+                article1?.blockTime,
+            )
+            assertNotNull(
+                "Article2 SHOULD be blocked when checking links (toggle ON)",
+                article2?.blockTime,
             )
 
             // Step 3: Toggle back to FALSE - should unblock
-            blocklistDao.setItemBlockStatus(Instant.now(), applyToSummaries = false)
+            blocklistDao.setItemBlockStatus(Instant.now(), applyToSummaries = false, applyToLinks = false)
 
-            article = feedItemDao.loadFeedItem(articleId)
+            article1 = feedItemDao.loadFeedItem(article1Id)
+            article2 = feedItemDao.loadFeedItem(article2Id)
+
             assertNull(
-                "Article should be unblocked when toggle is OFF again",
-                article?.blockTime,
+                "Article1 should be unblocked when toggle is OFF again",
+                article1?.blockTime,
+            )
+            assertNull(
+                "Article2 should be unblocked when toggle is OFF again",
+                article2?.blockTime,
             )
         }
 
     @Test
     fun addWordToBlocklist_withToggleAlreadyOn_blocksImmediately() =
         runBlocking {
-            // Create an article
-            val articleId =
+            // Create articles - one with keyword in snippet, one with keyword in link
+            val article1Id =
+                feedItemDao.insertFeedItem(
+                    FeedItem(
+                        guid = "test1",
+                        feedId = testFeedId,
+                        plainTitle = "Normal Title",
+                        plainSnippet = "This mentions advertisement in the summary.",
+                        pubDate = ZonedDateTime.now(),
+                        link = "https://example.com/article",
+                    ),
+                )
+            val article2Id =
                 feedItemDao.insertFeedItem(
                     FeedItem(
                         guid = "test2",
                         feedId = testFeedId,
                         plainTitle = "Normal Title",
-                        plainSnippet = "This mentions advertisement in the summary.",
+                        plainSnippet = "Normal snippet",
                         pubDate = ZonedDateTime.now(),
+                        link = "https://example.com/advertisement",
                     ),
                 )
 
             // First, apply blocklist with empty blocklist but toggle ON
-            blocklistDao.setItemBlockStatus(Instant.now(), applyToSummaries = true)
+            blocklistDao.setItemBlockStatus(Instant.now(), applyToSummaries = true, applyToLinks = true)
 
-            var article = feedItemDao.loadFeedItem(articleId)
-            assertNull("Article should not be blocked yet (no patterns)", article?.blockTime)
+            var article1 = feedItemDao.loadFeedItem(article1Id)
+            var article2 = feedItemDao.loadFeedItem(article2Id)
+
+            assertNull("Article1 should not be blocked yet (no patterns)", article1?.blockTime)
+            assertNull("Article2 should not be blocked yet (no patterns)", article2?.blockTime)
 
             // Now add "advertisement" to blocklist
             blocklistDao.insertSafely("advertisement")
 
             // Re-apply blocklist with toggle still ON
-            blocklistDao.setItemBlockStatus(Instant.now(), applyToSummaries = true)
+            blocklistDao.setItemBlockStatus(Instant.now(), applyToSummaries = true, applyToLinks = true)
 
-            article = feedItemDao.loadFeedItem(articleId)
+            article1 = feedItemDao.loadFeedItem(article1Id)
+            article2 = feedItemDao.loadFeedItem(article2Id)
+
             assertNotNull(
-                "Article SHOULD be blocked after adding pattern with toggle ON",
-                article?.blockTime,
+                "Article1 SHOULD be blocked after adding pattern with toggle ON",
+                article1?.blockTime,
+            )
+            assertNotNull(
+                "Article2 SHOULD be blocked after adding pattern with toggle ON",
+                article2?.blockTime,
             )
         }
 }

--- a/app/src/androidTest/java/com/nononsenseapps/feeder/model/opml/OPMLTest.kt
+++ b/app/src/androidTest/java/com/nononsenseapps/feeder/model/opml/OPMLTest.kt
@@ -784,6 +784,7 @@ class OPMLTest : DIAware {
                         UserSettings.SETTING_OPENAI_AZURE_DEPLOYMENT_ID -> "test-deployment"
                         UserSettings.SETTING_OPENAI_REQUEST_TIMEOUT_SECONDS -> "45"
                         UserSettings.SETTING_BLOCKLIST_APPLY_TO_SUMMARIES -> "true"
+                        UserSettings.SETTING_BLOCKLIST_APPLY_TO_LINKS -> "true"
                         UserSettings.SETTING_PREFERRED_TRANSLATION_LANGUAGE -> "sv"
                         UserSettings.SETTING_TRANSLATION_API_KEY -> "test-translation-api-key"
                         UserSettings.SETTING_TRANSLATION_API_MODEL_ID -> ""
@@ -873,6 +874,7 @@ private val sampleFile: List<String> =
           <feeder:setting key="pref_openai_azure_deployment_id" value="test-deployment"/>
           <feeder:setting key="pref_openai_request_timeout_seconds" value="45"/>
           <feeder:setting key="pref_blocklist_apply_to_summaries" value="true"/>
+          <feeder:setting key="pref_blocklist_apply_to_links" value="true"/>
           <feeder:setting key="pref_openai_translation_language" value="sv"/>
           <feeder:setting key="pref_translation_api_key" value="test-translation-api-key"/>
           <feeder:setting key="pref_translation_api_model_id" value=""/>

--- a/app/src/main/java/com/nononsenseapps/feeder/archmodel/FeedItemStore.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/archmodel/FeedItemStore.kt
@@ -52,7 +52,7 @@ class FeedItemStore(
         feedId: Long,
         blockTime: Instant,
     ) {
-        blocklistDao.setItemBlockStatusForNewInFeed(feedId, blockTime, settingsStore.applyBlocklistToSummaries.value)
+        blocklistDao.setItemBlockStatusForNewInFeed(feedId, blockTime, settingsStore.applyBlocklistToSummaries.value, settingsStore.applyBlocklistToLinks.value)
     }
 
     fun getFeedItemCountRaw(

--- a/app/src/main/java/com/nononsenseapps/feeder/archmodel/Repository.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/archmodel/Repository.kt
@@ -235,8 +235,15 @@ class Repository(
 
     val applyBlocklistToSummaries: StateFlow<Boolean> = settingsStore.applyBlocklistToSummaries
 
-    suspend fun setApplyBlocklistToSummaries(value: Boolean) {
+    fun setApplyBlocklistToSummaries(value: Boolean) {
         settingsStore.setApplyBlocklistToSummaries(value)
+        runOnceBlocklistUpdate(di)
+    }
+
+    val applyBlocklistToLinks: StateFlow<Boolean> = settingsStore.applyBlocklistToLinks
+
+    fun setApplyBlocklistToLinks(value: Boolean) {
+        settingsStore.setApplyBlocklistToLinks(value)
         runOnceBlocklistUpdate(di)
     }
 

--- a/app/src/main/java/com/nononsenseapps/feeder/archmodel/SettingsStore.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/archmodel/SettingsStore.kt
@@ -500,6 +500,17 @@ class SettingsStore(
         sp.edit().putBoolean(PREF_BLOCKLIST_APPLY_TO_SUMMARIES, value).apply()
     }
 
+    private val _applyBlocklistToLinks =
+        MutableStateFlow(
+            sp.getBoolean(PREF_BLOCKLIST_APPLY_TO_LINKS, false),
+        )
+    val applyBlocklistToLinks: StateFlow<Boolean> = _applyBlocklistToLinks.asStateFlow()
+
+    fun setApplyBlocklistToLinks(value: Boolean) {
+        _applyBlocklistToLinks.value = value
+        sp.edit().putBoolean(PREF_BLOCKLIST_APPLY_TO_LINKS, value).apply()
+    }
+
     private val _syncFrequency by lazy {
         MutableStateFlow(
             syncFrequencyFromString(sp.getStringNonNull(PREF_SYNC_FREQ, "60")),
@@ -675,6 +686,7 @@ const val PREF_SWIPE_AS_READ = "pref_swipe_as_read"
  * Block list settings
  */
 const val PREF_BLOCKLIST_APPLY_TO_SUMMARIES = "pref_blocklist_apply_to_summaries"
+const val PREF_BLOCKLIST_APPLY_TO_LINKS = "pref_blocklist_apply_to_links"
 
 /**
  * Sync settings
@@ -807,6 +819,7 @@ enum class UserSettings(
     SETTING_OPENAI_AZURE_DEPLOYMENT_ID(key = PREF_OPENAI_AZURE_DEPLOYMENT_ID),
     SETTING_OPENAI_REQUEST_TIMEOUT_SECONDS(key = PREF_OPENAI_REQUEST_TIMEOUT_SECONDS),
     SETTING_BLOCKLIST_APPLY_TO_SUMMARIES(key = PREF_BLOCKLIST_APPLY_TO_SUMMARIES),
+    SETTING_BLOCKLIST_APPLY_TO_LINKS(key = PREF_BLOCKLIST_APPLY_TO_LINKS),
     SETTING_PREFERRED_TRANSLATION_LANGUAGE(key = PREF_PREFERRED_TRANSLATION_LANGUAGE),
     SETTING_TRANSLATION_API_KEY(key = PREF_TRANSLATION_API_KEY),
     SETTING_TRANSLATION_API_MODEL_ID(key = PREF_TRANSLATION_API_MODEL_ID),

--- a/app/src/main/java/com/nononsenseapps/feeder/background/BlocklistUpdateJob.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/background/BlocklistUpdateJob.kt
@@ -39,11 +39,12 @@ class BlocklistUpdateJob(
         val onlyNew = params.extras.getBoolean(ARG_ONLY_NEW, false)
         val feedId = params.extras.getLong(ARG_FEED_ID, ID_UNSET)
         val applyToSummaries = settingsStore.applyBlocklistToSummaries.value
+        val applyToLinks = settingsStore.applyBlocklistToLinks.value
 
         when {
-            feedId != ID_UNSET -> blocklistDao.setItemBlockStatusForNewInFeed(feedId, Instant.now(), applyToSummaries)
-            onlyNew -> blocklistDao.setItemBlockStatusWhereNull(Instant.now(), applyToSummaries)
-            else -> blocklistDao.setItemBlockStatus(Instant.now(), applyToSummaries)
+            feedId != ID_UNSET -> blocklistDao.setItemBlockStatusForNewInFeed(feedId, Instant.now(), applyToSummaries, applyToLinks)
+            onlyNew -> blocklistDao.setItemBlockStatusWhereNull(Instant.now(), applyToSummaries, applyToLinks)
+            else -> blocklistDao.setItemBlockStatus(Instant.now(), applyToSummaries, applyToLinks)
         }
 
         logDebug(LOG_TAG, "Work done!")

--- a/app/src/main/java/com/nononsenseapps/feeder/db/room/BlocklistDao.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/db/room/BlocklistDao.kt
@@ -32,119 +32,69 @@ interface BlocklistDao {
     )
     fun getGlobPatterns(): Flow<List<String>>
 
+    @Query(
+        """
+            update feed_items
+            set block_time = case
+                when exists(
+                    select 1 from blocklist
+                    where lower(feed_items.plain_title) glob blocklist.glob_pattern
+                        or :applyToSummaries and lower(feed_items.plain_snippet) glob blocklist.glob_pattern
+                        or :applyToLinks and lower(feed_items.link) glob blocklist.glob_pattern
+                )
+                then coalesce(block_time, :blockTime)
+                else null
+                end
+        """,
+    )
     suspend fun setItemBlockStatus(
         blockTime: Instant,
         applyToSummaries: Boolean,
-    ) {
-        if (applyToSummaries) {
-            setItemBlockStatusWithSummaries(blockTime)
-        } else {
-            setItemBlockStatusTitleOnly(blockTime)
-        }
-    }
+        applyToLinks: Boolean,
+    )
 
     @Query(
         """
             update feed_items
             set block_time = case
-                when exists(select 1 from blocklist where lower(feed_items.plain_title) glob blocklist.glob_pattern)
-                then coalesce(block_time, :blockTime)
+                when exists(
+                    select 1 from blocklist
+                    where lower(feed_items.plain_title) glob blocklist.glob_pattern
+                        or :applyToSummaries and lower(feed_items.plain_snippet) glob blocklist.glob_pattern
+                        or :applyToLinks and lower(feed_items.link) glob blocklist.glob_pattern
+                )
+                then :blockTime
                 else null
                 end
+            where block_time is null
         """,
     )
-    suspend fun setItemBlockStatusTitleOnly(blockTime: Instant)
-
-    @Query(
-        """
-            update feed_items
-            set block_time = case
-                when exists(select 1 from blocklist where lower(feed_items.plain_title) glob blocklist.glob_pattern or lower(feed_items.plain_snippet) glob blocklist.glob_pattern)
-                then coalesce(block_time, :blockTime)
-                else null
-                end
-        """,
-    )
-    suspend fun setItemBlockStatusWithSummaries(blockTime: Instant)
-
     suspend fun setItemBlockStatusWhereNull(
         blockTime: Instant,
         applyToSummaries: Boolean,
-    ) {
-        if (applyToSummaries) {
-            setItemBlockStatusWhereNullWithSummaries(blockTime)
-        } else {
-            setItemBlockStatusWhereNullTitleOnly(blockTime)
-        }
-    }
+        applyToLinks: Boolean,
+    )
 
     @Query(
         """
             update feed_items
             set block_time = case
-                when exists(select 1 from blocklist where lower(feed_items.plain_title) glob blocklist.glob_pattern)
+                when exists(
+                    select 1 from blocklist
+                    where lower(feed_items.plain_title) glob blocklist.glob_pattern
+                        or :applyToSummaries and lower(feed_items.plain_snippet) glob blocklist.glob_pattern
+                        or :applyToLinks and lower(feed_items.link) glob blocklist.glob_pattern
+                )
                 then :blockTime
                 else null
                 end
-            where block_time is null
+            where feed_id = :feedId and block_time is null
         """,
     )
-    suspend fun setItemBlockStatusWhereNullTitleOnly(blockTime: Instant)
-
-    @Query(
-        """
-            update feed_items
-            set block_time = case
-                when exists(select 1 from blocklist where lower(feed_items.plain_title) glob blocklist.glob_pattern or lower(feed_items.plain_snippet) glob blocklist.glob_pattern)
-                then :blockTime
-                else null
-                end
-            where block_time is null
-        """,
-    )
-    suspend fun setItemBlockStatusWhereNullWithSummaries(blockTime: Instant)
-
     suspend fun setItemBlockStatusForNewInFeed(
         feedId: Long,
         blockTime: Instant,
         applyToSummaries: Boolean,
-    ) {
-        if (applyToSummaries) {
-            setItemBlockStatusForNewInFeedWithSummaries(feedId, blockTime)
-        } else {
-            setItemBlockStatusForNewInFeedTitleOnly(feedId, blockTime)
-        }
-    }
-
-    @Query(
-        """
-            update feed_items
-            set block_time = case
-                when exists(select 1 from blocklist where lower(feed_items.plain_title) glob blocklist.glob_pattern)
-                then :blockTime
-                else null
-                end
-            where feed_id = :feedId and block_time is null
-        """,
-    )
-    suspend fun setItemBlockStatusForNewInFeedTitleOnly(
-        feedId: Long,
-        blockTime: Instant,
-    )
-
-    @Query(
-        """
-            update feed_items
-            set block_time = case
-                when exists(select 1 from blocklist where lower(feed_items.plain_title) glob blocklist.glob_pattern or lower(feed_items.plain_snippet) glob blocklist.glob_pattern)
-                then :blockTime
-                else null
-                end
-            where feed_id = :feedId and block_time is null
-        """,
-    )
-    suspend fun setItemBlockStatusForNewInFeedWithSummaries(
-        feedId: Long,
-        blockTime: Instant,
+        applyToLinks: Boolean,
     )
 }

--- a/app/src/main/java/com/nononsenseapps/feeder/model/opml/OPMLImporter.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/opml/OPMLImporter.kt
@@ -158,6 +158,7 @@ open class OPMLImporter(
                 settingsStore.setTranslationApiSettings(newSettings)
             }
             UserSettings.SETTING_BLOCKLIST_APPLY_TO_SUMMARIES -> settingsStore.setApplyBlocklistToSummaries(value.toBoolean())
+            UserSettings.SETTING_BLOCKLIST_APPLY_TO_LINKS -> settingsStore.setApplyBlocklistToLinks(value.toBoolean())
         }
     }
 

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/settings/Settings.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/settings/Settings.kt
@@ -183,6 +183,8 @@ fun SettingsScreen(
             blockListValue = ImmutableHolder(viewState.blockList.sorted()),
             applyBlocklistToSummaries = viewState.applyBlocklistToSummaries,
             onApplyBlocklistToSummariesChange = settingsViewModel::setApplyBlocklistToSummaries,
+            applyBlocklistToLinks = viewState.applyBlocklistToLinks,
+            onApplyBlocklistToLinksChange = settingsViewModel::setApplyBlocklistToLinks,
             swipeAsReadValue = viewState.swipeAsRead,
             onSwipeAsReadOptionChange = settingsViewModel::setSwipeAsRead,
             syncOnStartupValue = viewState.syncOnResume,
@@ -285,6 +287,8 @@ private fun SettingsScreenPreview() {
             blockListValue = ImmutableHolder(emptyList()),
             applyBlocklistToSummaries = false,
             onApplyBlocklistToSummariesChange = {},
+            applyBlocklistToLinks = false,
+            onApplyBlocklistToLinksChange = {},
             swipeAsReadValue = SwipeAsRead.ONLY_FROM_END,
             onSwipeAsReadOptionChange = {},
             syncOnStartupValue = true,
@@ -374,6 +378,8 @@ fun SettingsList(
     blockListValue: ImmutableHolder<List<String>>,
     applyBlocklistToSummaries: Boolean,
     onApplyBlocklistToSummariesChange: (Boolean) -> Unit,
+    applyBlocklistToLinks: Boolean,
+    onApplyBlocklistToLinksChange: (Boolean) -> Unit,
     swipeAsReadValue: SwipeAsRead,
     onSwipeAsReadOptionChange: (SwipeAsRead) -> Unit,
     syncOnStartupValue: Boolean,
@@ -510,39 +516,57 @@ fun SettingsList(
                     .width(dimens.maxContentWidth),
         )
 
-        ListDialogSetting(
-            title = stringResource(id = R.string.block_list),
-            dialogTitle = {
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    Text(
-                        text = stringResource(id = R.string.block_list),
-                        style = MaterialTheme.typography.titleLarge,
-                    )
-                    Text(
-                        text = stringResource(id = R.string.block_list_description),
-                        style = MaterialTheme.typography.bodyMedium,
-                    )
-                    Text(
-                        text = "feeder feed?r fe*er",
-                        style = MaterialTheme.typography.bodySmall.copy(fontFamily = LocalTypographySettings.current.monoFontFamily),
-                    )
-                }
-            },
-            currentValue = blockListValue,
-            showToggle = true,
-            toggleValue = applyBlocklistToSummaries,
-            toggleLabel = stringResource(id = R.string.apply_blocklist_to_summaries),
-            onAddItem = onBlockListAdd,
-            onRemoveItem = onBlockListRemove,
-            onToggleChange = onApplyBlocklistToSummariesChange,
-        )
-
         NotificationsSetting(
             items = feedsSettings,
             onToggleItem = onToggleNotification,
         )
+
+        HorizontalDivider(modifier = Modifier.width(dimens.maxContentWidth))
+
+        SettingsGroup(
+            title = R.string.block_list,
+        ) {
+            ListDialogSetting(
+                title = stringResource(id = R.string.filters),
+                dialogTitle = {
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Text(
+                            text = stringResource(id = R.string.filters),
+                            style = MaterialTheme.typography.titleLarge,
+                        )
+                        Text(
+                            text = stringResource(id = R.string.block_list_description),
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                        Text(
+                            text = "feeder feed?r fe*er",
+                            style = MaterialTheme.typography.bodySmall.copy(fontFamily = LocalTypographySettings.current.monoFontFamily),
+                        )
+                    }
+                },
+                currentValue = blockListValue,
+                showToggle = false,
+                toggleValue = false,
+                toggleLabel = "",
+                onAddItem = onBlockListAdd,
+                onRemoveItem = onBlockListRemove,
+                onToggleChange = {},
+            )
+
+            SwitchSetting(
+                title = stringResource(id = R.string.apply_blocklist_to_summaries),
+                checked = applyBlocklistToSummaries,
+                onCheckedChange = onApplyBlocklistToSummariesChange,
+            )
+
+            SwitchSetting(
+                title = stringResource(id = R.string.apply_blocklist_to_links),
+                checked = applyBlocklistToLinks,
+                onCheckedChange = onApplyBlocklistToLinksChange,
+            )
+        }
 
         HorizontalDivider(modifier = Modifier.width(dimens.maxContentWidth))
 

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/settings/SettingsViewModel.kt
@@ -131,6 +131,11 @@ class SettingsViewModel(
             repository.setApplyBlocklistToSummaries(value)
         }
 
+    fun setApplyBlocklistToLinks(value: Boolean) =
+        applicationCoroutineScope.launch {
+            repository.setApplyBlocklistToLinks(value)
+        }
+
     fun toggleNotifications(
         feedId: Long,
         value: Boolean,
@@ -313,6 +318,7 @@ class SettingsViewModel(
                 downloadedLanguagePairs,
                 repository.useInAppAudioPlayer,
                 repository.forceSingleColumn,
+                repository.applyBlocklistToLinks,
             ) { params: Array<Any> ->
                 @Suppress("UNCHECKED_CAST")
                 SettingsViewState(
@@ -364,6 +370,7 @@ class SettingsViewModel(
                     translationModelPairs = params[38] as List<LanguagePairInfo>,
                     useInAppAudioPlayer = params[39] as Boolean,
                     forceSingleColumn = params[40] as Boolean,
+                    applyBlocklistToLinks = params[41] as Boolean,
                 )
             }.collect {
                 _viewState.value = it
@@ -459,6 +466,7 @@ data class SettingsViewState(
     val isAnimatedPaging: Boolean = false,
     val useInAppAudioPlayer: Boolean = true,
     val forceSingleColumn: Boolean = true,
+    val applyBlocklistToLinks: Boolean = false,
 )
 
 data class UIFeedSettings(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,6 +91,8 @@
   <string name="block_list">Block list</string>
   <string name="block_list_description">Hides articles with titles containing any of these filters. Example filters:</string>
   <string name="apply_blocklist_to_summaries">Apply to summaries</string>
+  <string name="apply_blocklist_to_links">Apply to links</string>
+  <string name="filters">Filters</string>
   <string name="add_item">Add item</string>
   <string name="show_fab">Show floating action button</string>
   <string name="include_mobile_hotspots">Include mobile hotspots</string>

--- a/app/src/test/java/com/nononsenseapps/feeder/archmodel/SettingsStoreTest.kt
+++ b/app/src/test/java/com/nononsenseapps/feeder/archmodel/SettingsStoreTest.kt
@@ -435,4 +435,37 @@ class SettingsStoreTest : DIAware {
 
         assertEquals(false, store.applyBlocklistToSummaries.value)
     }
+
+    @Test
+    fun applyBlocklistToLinksDefaultsToFalse() {
+        every { sp.getBoolean(PREF_BLOCKLIST_APPLY_TO_LINKS, false) } returns false
+
+        assertEquals(false, store.applyBlocklistToLinks.value)
+    }
+
+    @Test
+    fun applyBlocklistToLinksSetToTrue() {
+        store.setApplyBlocklistToLinks(true)
+
+        verify {
+            sp.edit().putBoolean(PREF_BLOCKLIST_APPLY_TO_LINKS, true).apply()
+        }
+
+        assertEquals(true, store.applyBlocklistToLinks.value)
+    }
+
+    @Test
+    fun applyBlocklistToLinksSetToFalse() {
+        every { sp.getBoolean(PREF_BLOCKLIST_APPLY_TO_LINKS, false) } returns true
+        clearMocks(sp, answers = false)
+        every { sp.getBoolean(PREF_BLOCKLIST_APPLY_TO_LINKS, false) } returns true
+
+        store.setApplyBlocklistToLinks(false)
+
+        verify {
+            sp.edit().putBoolean(PREF_BLOCKLIST_APPLY_TO_LINKS, false).apply()
+        }
+
+        assertEquals(false, store.applyBlocklistToLinks.value)
+    }
 }

--- a/app/src/test/java/com/nononsenseapps/feeder/model/opml/OpmlParserTest.kt
+++ b/app/src/test/java/com/nononsenseapps/feeder/model/opml/OpmlParserTest.kt
@@ -93,6 +93,7 @@ class OpmlParserTest : DIAware {
                         UserSettings.SETTING_OPENAI_AZURE_DEPLOYMENT_ID -> "test-deployment"
                         UserSettings.SETTING_OPENAI_REQUEST_TIMEOUT_SECONDS -> "45"
                         UserSettings.SETTING_BLOCKLIST_APPLY_TO_SUMMARIES -> "true"
+                        UserSettings.SETTING_BLOCKLIST_APPLY_TO_LINKS -> "true"
                         UserSettings.SETTING_PREFERRED_TRANSLATION_LANGUAGE -> "French"
                         UserSettings.SETTING_TRANSLATION_API_KEY -> "translation-api-key"
                         UserSettings.SETTING_TRANSLATION_API_MODEL_ID -> ""
@@ -158,6 +159,7 @@ class OpmlParserTest : DIAware {
                 settingsStore.setTranslateArticlePreviewsByDefault(true)
                 settingsStore.setTranslateArticlesByDefault(true)
                 settingsStore.setApplyBlocklistToSummaries(true)
+                settingsStore.setApplyBlocklistToLinks(true)
                 settingsStore.setForceSingleColumn(true)
             }
 

--- a/app/src/test/java/com/nononsenseapps/feeder/model/opml/OpmlWriterKtTest.kt
+++ b/app/src/test/java/com/nononsenseapps/feeder/model/opml/OpmlWriterKtTest.kt
@@ -154,6 +154,7 @@ class OpmlWriterKtTest {
               <feeder:setting key="pref_openai_azure_deployment_id" value="test-deployment"/>
               <feeder:setting key="pref_openai_request_timeout_seconds" value="45"/>
               <feeder:setting key="pref_blocklist_apply_to_summaries" value="true"/>
+              <feeder:setting key="pref_blocklist_apply_to_links" value="true"/>
               <feeder:setting key="pref_openai_translation_language" value="French"/>
               <feeder:setting key="pref_translation_api_key" value="translation-api-key"/>
               <feeder:setting key="pref_translation_api_model_id" value=""/>
@@ -216,6 +217,7 @@ class OpmlWriterKtTest {
                         UserSettings.SETTING_OPENAI_AZURE_DEPLOYMENT_ID -> "test-deployment"
                         UserSettings.SETTING_OPENAI_REQUEST_TIMEOUT_SECONDS -> "45"
                         UserSettings.SETTING_BLOCKLIST_APPLY_TO_SUMMARIES -> "true"
+                        UserSettings.SETTING_BLOCKLIST_APPLY_TO_LINKS -> "true"
                         UserSettings.SETTING_PREFERRED_TRANSLATION_LANGUAGE -> "French"
                         UserSettings.SETTING_TRANSLATION_API_KEY -> "translation-api-key"
                         UserSettings.SETTING_TRANSLATION_API_MODEL_ID -> ""


### PR DESCRIPTION
## What does this change?

This PR adds a toggle to apply the block list to article links. Similar to #1003

- New setting is opt-in
- Setting is exportable
- Added a settings group for all block list related features (see image)
- Adjusted tests

I really need this feature because some news feeds are really bloated with articles that are not interesting to me 🥲

## Checklist

- [x] Ran `./gradlew ktlintFormat` and committed the result
- [ ] If the Room schema changed: added a `MIGRATION_N_N+1` in `AppDatabase.kt`
- [ ] If the Room schema changed: added a migration test in `app/src/androidTest/.../db/room/`

## Screenshots (if UI change)

coming as soon as i figure out how to insert images lol
