### PR TITLE
fix: reset TTS queue on article switch and resume same article only

### DIFF
--- a/app/src/main/java/com/nononsenseapps/feeder/model/ReadAloudStateHolder.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/ReadAloudStateHolder.kt
@@ -77,6 +77,7 @@ class TTSStateHolder(
         }
     }
     private val textToSpeechQueue = mutableListOf<CharSequence>()
+    private var queuedArticleId: Long? = null
     private var initializedState: Int? = null
     private var startJob: Job? = null
 
@@ -141,12 +142,18 @@ class TTSStateHolder(
         }
     }
 
+    fun queuedArticleId(): Long? = queuedArticleId
+
     fun tts(
         textArray: List<AnnotatedString>,
         useDetectLanguage: Boolean,
+        articleId: Long,
     ) {
         this.useDetectLanguage = useDetectLanguage
-//        val textArray = fullText.split(*PUNCTUATION)
+        startJob?.cancel()
+        textToSpeech?.stop()
+        textToSpeechQueue.clear()
+        queuedArticleId = articleId
         for (text in textArray) {
             if (text.isBlank()) {
                 continue
@@ -212,6 +219,7 @@ class TTSStateHolder(
         startJob?.cancel()
         textToSpeech?.stop()
         textToSpeechQueue.clear()
+        queuedArticleId = null
         _ttsState.value = PlaybackStatus.STOPPED
         textToSpeech = null
     }

--- a/app/src/main/java/com/nononsenseapps/feeder/model/ReadAloudStateHolder.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/ReadAloudStateHolder.kt
@@ -142,7 +142,18 @@ class TTSStateHolder(
         }
     }
 
-    fun queuedArticleId(): Long? = queuedArticleId
+    /**
+     * Resumes the paused queue when it already holds [articleId], so pressing play on the
+     * article being read continues it instead of re-reading it from the top. Returns false
+     * when the caller still has to build a queue.
+     */
+    fun resumeIfPausedOn(articleId: Long): Boolean {
+        if (_ttsState.value != PlaybackStatus.PAUSED || queuedArticleId != articleId) {
+            return false
+        }
+        play()
+        return true
+    }
 
     fun tts(
         textArray: List<AnnotatedString>,

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleViewModel.kt
@@ -462,10 +462,7 @@ class ArticleViewModel(
 
     fun ttsPlay() {
         stopPodcastPlayback()
-        if (ttsStateHolder.ttsState.value == PlaybackStatus.PAUSED &&
-            ttsStateHolder.queuedArticleId() == itemId
-        ) {
-            ttsStateHolder.play()
+        if (ttsStateHolder.resumeIfPausedOn(itemId)) {
             return
         }
         viewModelScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/ArticleViewModel.kt
@@ -462,6 +462,12 @@ class ArticleViewModel(
 
     fun ttsPlay() {
         stopPodcastPlayback()
+        if (ttsStateHolder.ttsState.value == PlaybackStatus.PAUSED &&
+            ttsStateHolder.queuedArticleId() == itemId
+        ) {
+            ttsStateHolder.play()
+            return
+        }
         viewModelScope.launch(Dispatchers.IO) {
             val feedItem = repository.getCurrentArticle() ?: return@launch
             val article = Article(feedItem)
@@ -524,6 +530,7 @@ class ArticleViewModel(
                 ttsStateHolder.tts(
                     textArray = it,
                     useDetectLanguage = repository.useDetectLanguage.value,
+                    articleId = itemId,
                 )
             }
         }

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/FeedViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/FeedViewModel.kt
@@ -585,10 +585,7 @@ class FeedViewModel(
             val article =
                 repository.getCurrentArticle()
                     ?: return@launch
-            if (ttsStateHolder.ttsState.value == PlaybackStatus.PAUSED &&
-                ttsStateHolder.queuedArticleId() == article.id
-            ) {
-                ttsStateHolder.play()
+            if (ttsStateHolder.resumeIfPausedOn(article.id)) {
                 return@launch
             }
             val isFullText = repository.shouldDisplayFullTextForItemByDefault(article.id)

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/FeedViewModel.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/feedarticle/FeedViewModel.kt
@@ -585,6 +585,12 @@ class FeedViewModel(
             val article =
                 repository.getCurrentArticle()
                     ?: return@launch
+            if (ttsStateHolder.ttsState.value == PlaybackStatus.PAUSED &&
+                ttsStateHolder.queuedArticleId() == article.id
+            ) {
+                ttsStateHolder.play()
+                return@launch
+            }
             val isFullText = repository.shouldDisplayFullTextForItemByDefault(article.id)
             val textToRead =
                 when (isFullText) {
@@ -631,6 +637,7 @@ class FeedViewModel(
                 ttsStateHolder.tts(
                     textArray = it,
                     useDetectLanguage = repository.useDetectLanguage.value,
+                    articleId = article.id,
                 )
             }
         }


### PR DESCRIPTION
## What does this change?

Pausing read-aloud and opening another article left the old utterance chunks in `TTSStateHolder`'s queue, so play resumed the previous article (#1177). Pressing play again on the same paused article also rebuilt the whole queue from scratch (#1178).

I clear/stop the queue when `tts()` loads a new article, track `queuedArticleId`, and only short-circuit `ttsPlay()` to `play()` when we're still paused on that same article.

Fixes #1177
Fixes #1178

## Checklist

- [ ] Ran `./gradlew ktlintFormat` and committed the result — no Java runtime on my machine, couldn't run Gradle here
- [ ] If the Room schema changed: added a `MIGRATION_N_N+1` in `AppDatabase.kt`
- [ ] If the Room schema changed: added a migration test in `app/src/androidTest/.../db/room/`

## Screenshots (if UI change)

n/a — playback state fix, no UI chrome change
