### PR TITLE
Add support for API 24+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
       # Then start the emulator and run the Instrumentation tests!
       - android/start-emulator-and-run-tests:
           test-command: ./gradlew connectedDebugAndroidTest --parallel
-          system-image: system-images;android-29;google_apis;x86
+          system-image: system-images;android-25;google_apis;x86
 
       # And finally run the release build
       #- run:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,8 +42,7 @@ android {
         // For actual releases they match.
         versionCode = 4094
         versionName = "2.23.1"
-        // TLS1.3 is enabled in Android 10 (29) and above
-        minSdk = 29
+        minSdk = 24
         targetSdk =
             libs.versions.compileSdk
                 .get()

--- a/app/src/main/java/com/nononsenseapps/feeder/FeederApplication.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/FeederApplication.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.app.job.JobScheduler
 import android.content.ContentResolver
 import android.content.SharedPreferences
+import android.util.Log
 import android.widget.Toast
 import androidx.core.app.NotificationManagerCompat
 import androidx.preference.PreferenceManager
@@ -54,6 +55,7 @@ import okhttp3.Cache
 import okhttp3.CacheControl
 import okhttp3.OkHttpClient
 import okio.Path.Companion.toOkioPath
+import org.conscrypt.Conscrypt
 import org.kodein.di.DI
 import org.kodein.di.DIAware
 import org.kodein.di.bind
@@ -61,6 +63,7 @@ import org.kodein.di.direct
 import org.kodein.di.instance
 import org.kodein.di.singleton
 import java.io.File
+import java.security.Security
 import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalCoilApi::class)
@@ -212,6 +215,17 @@ class FeederApplication :
         bind<TTSStateHolder>() with instance(ttsStateHolder)
         bind<PodcastPlayerStateHolder>() with instance(podcastPlayerStateHolder)
         bind<NotificationsWorker>() with singleton { NotificationsWorker(di) }
+    }
+
+    init {
+        // Install Conscrypt to handle TLSv1.3 pre Android10
+        // This crashes if app is installed to SD-card. Since it should still work for many
+        // devices, try to ignore errors
+        try {
+            Security.insertProviderAt(Conscrypt.newProvider(), 1)
+        } catch (t: Throwable) {
+            Log.e(LOG_TAG, "Failed to insert Conscrypt. Attempt to ignore.", t)
+        }
     }
 
     override fun onCreate() {

--- a/app/src/main/java/com/nononsenseapps/feeder/archmodel/AndroidSystemStore.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/archmodel/AndroidSystemStore.kt
@@ -3,6 +3,7 @@ package com.nononsenseapps.feeder.archmodel
 import android.app.Application
 import android.content.Context
 import android.content.pm.ShortcutManager
+import android.os.Build
 import org.kodein.di.DI
 import org.kodein.di.DIAware
 import org.kodein.di.instance
@@ -18,7 +19,9 @@ class AndroidSystemStore(
     private val application: Application by instance()
 
     fun removeDynamicShortcuts(feedIds: List<Long>) {
-        val shortcutManager = application.getSystemService(Context.SHORTCUT_SERVICE) as ShortcutManager
-        shortcutManager.removeDynamicShortcuts(feedIds.map { it.toString() })
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+            val shortcutManager = application.getSystemService(Context.SHORTCUT_SERVICE) as ShortcutManager
+            shortcutManager.removeDynamicShortcuts(feedIds.map { it.toString() })
+        }
     }
 }

--- a/app/src/main/java/com/nononsenseapps/feeder/background/Notifications.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/background/Notifications.kt
@@ -41,7 +41,9 @@ fun getNotification(
     context: Context,
     notificationManager: NotificationManagerCompat,
 ): Notification {
-    createNotificationChannel(context, notificationManager)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        createNotificationChannel(context, notificationManager)
+    }
 
     val syncingText = context.getString(R.string.syncing)
 

--- a/app/src/main/java/com/nononsenseapps/feeder/localtranslation/BergamotModelManager.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/localtranslation/BergamotModelManager.kt
@@ -24,8 +24,6 @@ import org.kodein.di.DI
 import org.kodein.di.DIAware
 import org.kodein.di.instance
 import java.io.File
-import java.nio.file.Files
-import java.nio.file.StandardCopyOption
 import java.security.MessageDigest
 import java.util.Locale
 
@@ -501,19 +499,10 @@ class BergamotModelManager(
         destination: File,
     ): Boolean =
         runCatching {
-            Files.move(
-                tempFile.toPath(),
-                destination.toPath(),
-                StandardCopyOption.REPLACE_EXISTING,
-                StandardCopyOption.ATOMIC_MOVE,
-            )
-            true
-        }.recoverCatching {
-            Files.move(
-                tempFile.toPath(),
-                destination.toPath(),
-                StandardCopyOption.REPLACE_EXISTING,
-            )
+            if (!tempFile.renameTo(destination)) {
+                tempFile.copyTo(destination, overwrite = true)
+                tempFile.delete()
+            }
             true
         }.getOrElse {
             tempFile.delete()

--- a/app/src/main/java/com/nononsenseapps/feeder/localtranslation/LocalTranslator.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/localtranslation/LocalTranslator.kt
@@ -569,15 +569,19 @@ class LocalTranslator(
                     preserveHtml = preserveHtml,
                 ).filter(::hasEnoughTextForLanguageDetection)
                     .mapNotNull { sample ->
-                        application
-                            .detectLocaleFromText(
-                                text = sample,
-                                minConfidence = 60.0f,
-                            ).firstOrNull()
-                            ?.locale
-                            ?.language
-                            ?.let(::normalizeLanguageCode)
-                            ?.takeIf { it != "und" }
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                            application
+                                .detectLocaleFromText(
+                                    text = sample,
+                                    minConfidence = 60.0f,
+                                ).firstOrNull()
+                                ?.locale
+                                ?.language
+                                ?.let(::normalizeLanguageCode)
+                                ?.takeIf { it != "und" }
+                        } else {
+                            null
+                        }
                     }
 
             val languageCounts = detectedLanguages.groupingBy { it }.eachCount()

--- a/app/src/main/java/com/nononsenseapps/feeder/model/ReadAloudStateHolder.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/ReadAloudStateHolder.kt
@@ -99,8 +99,8 @@ class TTSStateHolder(
         textToSpeechQueue.firstOrNull()?.let { text ->
             val lang = _language.value
             val localesToUse: Sequence<Locale> =
-                when (lang) {
-                    is ForcedAuto -> {
+                when {
+                    lang is ForcedAuto && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q -> {
                         context
                             .detectLocaleFromText(text)
                             .sortedByDescending { it.confidence }
@@ -108,7 +108,7 @@ class TTSStateHolder(
                             .plus(_availableLanguages.value)
                     }
 
-                    is ForcedLocale -> {
+                    lang is ForcedLocale -> {
                         sequenceOf(
                             lang.locale,
                         )
@@ -116,7 +116,7 @@ class TTSStateHolder(
 
                     else -> {
                         // Use app setting
-                        if (useDetectLanguage) {
+                        if (useDetectLanguage && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                             context
                                 .detectLocaleFromText(text)
                                 .sortedByDescending { it.confidence }
@@ -270,21 +270,32 @@ class TTSStateHolder(
         allAvailableLanguages = textToSpeech?.availableLanguages ?: emptySet()
 
         val sortedLanguages =
-            context
-                .detectLocaleFromText(
-                    textToSpeechQueue.joinToString("\n\n"),
-                    minConfidence = 0f,
-                ).sortedByDescending { it.confidence }
-                .map { it.locale }
-                .plus(
-                    context
-                        .getLocales()
-                        .sortedBy { it.getDisplayName(it).lowercase(it) },
-                ).plus(
-                    allAvailableLanguages
-                        .asSequence()
-                        .sortedBy { it.getDisplayName(it).lowercase(it) },
-                ).distinctBy { it.toLanguageTag() }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                context
+                    .detectLocaleFromText(
+                        textToSpeechQueue.joinToString("\n\n"),
+                        minConfidence = 0f,
+                    ).sortedByDescending { it.confidence }
+                    .map { it.locale }
+                    .plus(
+                        context
+                            .getLocales()
+                            .sortedBy { it.getDisplayName(it).lowercase(it) },
+                    ).plus(
+                        allAvailableLanguages
+                            .asSequence()
+                            .sortedBy { it.getDisplayName(it).lowercase(it) },
+                    )
+            } else {
+                context
+                    .getLocales()
+                    .sortedBy { it.displayName }
+                    .plus(
+                        allAvailableLanguages
+                            .asSequence()
+                            .sortedBy { it.getDisplayName(it).lowercase(it) },
+                    )
+            }.distinctBy { it.toLanguageTag() }
                 .toList()
 
         _availableLanguages.update {

--- a/app/src/main/java/com/nononsenseapps/feeder/model/RssNotifications.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/RssNotifications.kt
@@ -65,7 +65,9 @@ suspend fun notify(
         return@withContext
     }
 
-    createNotificationChannel(appContext)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        createNotificationChannel(appContext)
+    }
 
     val di by closestDI(appContext)
 

--- a/app/src/main/java/com/nononsenseapps/feeder/model/TranslationManager.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/model/TranslationManager.kt
@@ -1,6 +1,7 @@
 package com.nononsenseapps.feeder.model
 
 import android.app.Application
+import android.os.Build
 import com.nononsenseapps.feeder.archmodel.OpenAISettings
 import com.nononsenseapps.feeder.archmodel.Repository
 import com.nononsenseapps.feeder.archmodel.TranslationApiSettings
@@ -580,13 +581,17 @@ class TranslationManager(
             val detectedLanguages =
                 detectionSamples.map { sample ->
                     val detectedLanguage =
-                        application
-                            .detectLocaleFromText(
-                                text = sample,
-                                minConfidence = 95.0f,
-                            ).firstOrNull()
-                            ?.locale
-                            ?.toLanguageTag()
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                            application
+                                .detectLocaleFromText(
+                                    text = sample,
+                                    minConfidence = 95.0f,
+                                ).firstOrNull()
+                                ?.locale
+                                ?.toLanguageTag()
+                        } else {
+                            null
+                        }
                             ?: return@runCatching null
 
                     if (

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/readaloud/ReadAloudPlayer.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/readaloud/ReadAloudPlayer.kt
@@ -1,5 +1,6 @@
 package com.nononsenseapps.feeder.ui.compose.readaloud
 
+import android.os.Build
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.MutableTransitionState
@@ -191,15 +192,17 @@ fun TTSPlayer(
                             Text(stringResource(id = R.string.use_app_default))
                         },
                     )
-                    DropdownMenuItem(
-                        onClick = {
-                            onSelectLanguage(ForcedAuto)
-                            showMenu = false
-                        },
-                        text = {
-                            Text(stringResource(id = R.string.use_detect_language))
-                        },
-                    )
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                        DropdownMenuItem(
+                            onClick = {
+                                onSelectLanguage(ForcedAuto)
+                                showMenu = false
+                            },
+                            text = {
+                                Text(stringResource(id = R.string.use_detect_language))
+                            },
+                        )
+                    }
                     HorizontalDivider()
                     for (lang in languages.item) {
                         DropdownMenuItem(

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/settings/Settings.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/settings/Settings.kt
@@ -453,6 +453,10 @@ fun SettingsList(
 ) {
     val scrollState = rememberScrollState()
     val dimens = LocalDimens.current
+    val isAndroidQAndAbove =
+        remember {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+        }
     val isAndroidSAndAbove =
         remember {
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
@@ -858,7 +862,16 @@ fun SettingsList(
                 title = stringResource(id = R.string.use_detect_language),
                 checked = useDetectLanguage,
                 onCheckedChange = onUseDetectLanguageChange,
-                description = stringResource(id = R.string.description_for_read_aloud),
+                description =
+                    when {
+                        isAndroidQAndAbove -> stringResource(id = R.string.description_for_read_aloud)
+                        else ->
+                            stringResource(
+                                id = R.string.only_available_on_android_n,
+                                "10",
+                            )
+                    },
+                enabled = isAndroidQAndAbove,
             )
         }
 

--- a/app/src/main/java/com/nononsenseapps/feeder/ui/compose/theme/Theme.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/ui/compose/theme/Theme.kt
@@ -250,7 +250,19 @@ private fun ThemeOptions.isDarkSystemIcons(): Boolean {
 @Composable
 private fun ThemeOptions.isDarkNavIcons(): Boolean {
     // Only Api 27+ supports dark nav bar icons
-    return isDarkSystemIcons()
+    return (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) && isDarkSystemIcons()
+}
+
+@Composable
+private fun ThemeOptions.getNavBarColor(): Color {
+    // Api 29 handles transparency
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        Color.Transparent
+    } else if (isDarkNavIcons()) {
+        NavBarScrimLight
+    } else {
+        NavBarScrimDark
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/nononsenseapps/feeder/util/ContextExtensions.kt
+++ b/app/src/main/java/com/nononsenseapps/feeder/util/ContextExtensions.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.content.pm.ShortcutInfo
 import android.content.pm.ShortcutManager
 import android.graphics.drawable.Icon
+import android.os.Build
 import android.util.Log
 import androidx.annotation.StringRes
 import androidx.core.app.NotificationManagerCompat
@@ -35,54 +36,56 @@ fun Context.addDynamicShortcutToFeed(
     icon: Icon? = null,
 ) {
     try {
-        val shortcutManager = getSystemService(ShortcutManager::class.java) ?: return
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+            val shortcutManager = getSystemService(ShortcutManager::class.java) ?: return
 
-        val intent =
-            Intent(
-                Intent.ACTION_VIEW,
-                "$DEEP_LINK_BASE_URI/feed?id=$id".toUri(),
-                this,
-                MainActivity::class.java,
-            ).apply {
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            }
-
-        val current = shortcutManager.dynamicShortcuts.toMutableList()
-
-        // Update shortcuts
-        val shortcut: ShortcutInfo =
-            ShortcutInfo
-                .Builder(this, "$id")
-                .setShortLabel(label)
-                .setLongLabel(label)
-                .setIcon(
-                    icon
-                        ?: Icon.createWithBitmap(
-                            getLetterIcon(
-                                label,
-                                id,
-                                radius = shortcutManager.iconMaxHeight,
-                            ),
-                        ),
-                ).setIntent(intent)
-                .setDisabledMessage("Feed deleted")
-                .setRank(0)
-                .build()
-
-        if (current.map { it.id }.contains(shortcut.id)) {
-            // Just update existing one
-            shortcutManager.updateShortcuts(listOf(shortcut))
-        } else {
-            // Ensure we do not exceed max limits
-            if (current.size >= shortcutManager.maxShortcutCountPerActivity.coerceAtMost(3)) {
-                current.sortBy { it.rank }
-                current.lastOrNull()?.let {
-                    shortcutManager.removeDynamicShortcuts(listOf(it.id))
+            val intent =
+                Intent(
+                    Intent.ACTION_VIEW,
+                    "$DEEP_LINK_BASE_URI/feed?id=$id".toUri(),
+                    this,
+                    MainActivity::class.java,
+                ).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 }
-            }
 
-            // It's new!
-            shortcutManager.addDynamicShortcuts(listOf(shortcut))
+            val current = shortcutManager.dynamicShortcuts.toMutableList()
+
+            // Update shortcuts
+            val shortcut: ShortcutInfo =
+                ShortcutInfo
+                    .Builder(this, "$id")
+                    .setShortLabel(label)
+                    .setLongLabel(label)
+                    .setIcon(
+                        icon
+                            ?: Icon.createWithBitmap(
+                                getLetterIcon(
+                                    label,
+                                    id,
+                                    radius = shortcutManager.iconMaxHeight,
+                                ),
+                            ),
+                    ).setIntent(intent)
+                    .setDisabledMessage("Feed deleted")
+                    .setRank(0)
+                    .build()
+
+            if (current.map { it.id }.contains(shortcut.id)) {
+                // Just update existing one
+                shortcutManager.updateShortcuts(listOf(shortcut))
+            } else {
+                // Ensure we do not exceed max limits
+                if (current.size >= shortcutManager.maxShortcutCountPerActivity.coerceAtMost(3)) {
+                    current.sortBy { it.rank }
+                    current.lastOrNull()?.let {
+                        shortcutManager.removeDynamicShortcuts(listOf(it.id))
+                    }
+                }
+
+                // It's new!
+                shortcutManager.addDynamicShortcuts(listOf(shortcut))
+            }
         }
     } catch (error: Throwable) {
         Log.d("FeederDynamicShortcut", "Error during add of shortcut: ${error.message}")
@@ -95,8 +98,10 @@ fun Context.addDynamicShortcutToFeed(
  */
 fun Context.reportShortcutToFeedUsed(id: Any) {
     try {
-        val shortcutManager = getSystemService(ShortcutManager::class.java) ?: return
-        shortcutManager.reportShortcutUsed("$id")
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+            val shortcutManager = getSystemService(ShortcutManager::class.java) ?: return
+            shortcutManager.reportShortcutUsed("$id")
+        }
     } catch (error: Throwable) {
         Log.d("FeederDynamicShortcut", "Error during report use of shortcut: ${error.message}")
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ compileSdk = "36"
 # BEGIN These should be upgraded in unison. See https://square.github.io/okhttp/changelogs/changelog_4x/
 okhttp = "5.3.2"
 okio = "3.16.2"
+conscrypt = "2.6.3"
 # END Unison
 ktlint-gradle = "14.2.0"
 ktlint-compose = "0.6.4"
@@ -100,6 +101,7 @@ gofeed-android = { module = "com.nononsenseapps.gofeed:gofeed-android", version.
 jetbrains-markdown = { module = "org.jetbrains:markdown", version.ref = "jetbrains-markdown" }
 okhttp = { module = "com.squareup.okhttp3:okhttp" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
+conscrypt-android = { module = "org.conscrypt:conscrypt-android", version.ref = "conscrypt" }
 coil-gif = { module = "io.coil-kt.coil3:coil-gif", version.ref = "coil" }
 coil-svg = { module = "io.coil-kt.coil3:coil-svg", version.ref = "coil" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
@@ -147,7 +149,7 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 ktlint-gradle = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-gradle" }
 
 [bundles]
-okhttp-android = ["okhttp", "okio"]
+okhttp-android = ["okhttp", "okio", "conscrypt-android"]
 kotlin = ["kotlin-stdlib", "kotlin-stdlib-common", "kotlin-coroutines-core", "kotlin-serialization-json"]
 jvm = ["jsoup", "tagsoup", "readability4j", "retrofit", "retrofit-converter-moshi", "moshi", "moshi-kotlin", "moshi-adapters", "qrgen", "gofeed-android", "icu4j"]
 android = ["lifecycle-runtime-ktx", "lifecycle-viewmodel-ktx", "lifecycle-viewmodel-savedstate", "paging-runtime-ktx", "room-ktx", "room-paging", "core-ktx", "androidx-appcompat", "androidx-preference", "coil-gif", "coil-svg", "coil-okhttp", "kotlin-coroutines-android", "kodein-androidx", "androidx-browser", "emoji2", "emoji2-view-helper"]


### PR DESCRIPTION
## What does this change?

Updating to conscrypt 2.6.3 fixes all the previous errors that caused legacy support to be removed.

## Checklist

- [x] Ran `./gradlew ktlintFormat` and committed the result
- [x] If the Room schema changed: added a `MIGRATION_N_N+1` in `AppDatabase.kt`
- [x] If the Room schema changed: added a migration test in `app/src/androidTest/.../db/room/`

## Screenshots (if UI change)

<!-- Optional: before/after screenshots or screen recordings. -->
